### PR TITLE
v.0.0.7 Sync date windows, 10k row_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.7
+  * Add date window looping logic to the `sync` function in `sync.py`. Increase the `row_limit` for `performance_reports` to 10,000.
+
 ## 0.0.6
   * Fix/simplify bookmarking and paging issues for organizations with a large number of results. Add 14 day attribution window to account for results lag time.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-google-search-console',
-      version='0.0.6',
+      version='0.0.7',
       description='Singer.io tap for extracting data from the Google Search Console API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_google_search_console/streams.py
+++ b/tap_google_search_console/streams.py
@@ -40,7 +40,7 @@ STREAMS = {
         'path': 'sites/{}/searchAnalytics/query',
         'data_key': 'rows',
         'api_method': 'POST',
-        'row_limit': 1000,
+        'row_limit': 10000,
         'body': {
             'aggregationType': 'auto'
         },
@@ -56,7 +56,7 @@ STREAMS = {
         'path': 'sites/{}/searchAnalytics/query',
         'data_key': 'rows',
         'api_method': 'POST',
-        'row_limit': 1000,
+        'row_limit': 10000,
         'body': {
             'aggregationType': 'byProperty',
             'dimensions': ['date']
@@ -73,7 +73,7 @@ STREAMS = {
         'path': 'sites/{}/searchAnalytics/query',
         'data_key': 'rows',
         'api_method': 'POST',
-        'row_limit': 1000,
+        'row_limit': 10000,
         'body': {
             'aggregationType': 'byProperty',
             'dimensions': ['date', 'country']
@@ -90,7 +90,7 @@ STREAMS = {
         'path': 'sites/{}/searchAnalytics/query',
         'data_key': 'rows',
         'api_method': 'POST',
-        'row_limit': 1000,
+        'row_limit': 10000,
         'body': {
             'aggregationType': 'byProperty',
             'dimensions': ['date', 'device']
@@ -107,7 +107,7 @@ STREAMS = {
         'path': 'sites/{}/searchAnalytics/query',
         'data_key': 'rows',
         'api_method': 'POST',
-        'row_limit': 1000,
+        'row_limit': 10000,
         'body': {
             'aggregationType': 'byPage',
             'dimensions': ['date', 'page']
@@ -124,7 +124,7 @@ STREAMS = {
         'path': 'sites/{}/searchAnalytics/query',
         'data_key': 'rows',
         'api_method': 'POST',
-        'row_limit': 1000,
+        'row_limit': 10000,
         'body': {
             'aggregationType': 'byProperty',
             'dimensions': ['date', 'query']


### PR DESCRIPTION
# Description of change
Add date window looping logic to the `sync` function in `sync.py`. Increase the `row_limit` for `performance_reports` to 10,000.
Fixes identified issue where tap is timing out after 6 hrs with state being updated after each 30-day date window. When tap re-starts, it will resume last date window.

# Manual QA steps
Ran singer-discover, singer-check-tap, target-stitch initial sync and incremental sync. Verified date windows loop via logs and record counts and target DWH.
 
# Risks
Low, but several clients currently using beta tap. Clients may want to re-sync history (but only if they were timing out after 6 hrs).
 
# Rollback steps
Revert to v.0.0.6
