### PR TITLE
Raise error and fail fast if missing pk in record instead of just logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,61 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+    steps:
+      - checkout
+      - add_ssh_keys
+      - run:
+          name: 'Setup virtual env'
+          command: |
+            python3 -mvenv /usr/local/share/virtualenvs/tap-google-search-console
+            source /usr/local/share/virtualenvs/tap-google-search-console/bin/activate
+            pip install -U pip setuptools
+            pip install .[dev]
+      # TODO: Fails pylint, skipping for now
+      #- run:
+      #    name: 'pylint tap'
+      #    command: |
+      #      source /usr/local/share/virtualenvs/tap-google-search-console/bin/activate
+      #      pylint tap_google_search_console -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,too-many-public-methods'
+      - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            stitch-validate-json /usr/local/share/virtualenvs/tap-google-search-console/lib/python3.5/site-packages/tap_google_search_console/schemas/*.json
+      - run:
+          name: 'Integration Tests Setup'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+      # TODO: Move tests over from tap-tester repo, leaving out for now
+      #- run:
+      #    name: 'Integration Tests'
+      #    command: |
+      #      source dev_env.sh
+      #      source /usr/local/share/virtualenvs/tap-tester/bin/activate
+      #      PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-google-search-console/lib/python3.5/site-packages/ \
+      #      run-test --tap=tap-google-search-console \
+      #               --target=target-stitch \
+      #               --orchestrator=stitch-orchestrator \
+      #               --email=harrison+sandboxtest@stitchdata.com \
+      #               --password=$SANDBOX_PASSWORD \
+      #               --client-id=50 \
+      #               tests/tap_combined_test.py
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build:
+          context: circleci-user
+  build_daily:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          context: circleci-user

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,12 @@ setup(name='tap-google-search-console',
           'requests==2.22.0',
           'singer-python==5.8.1'
       ],
+      extras_require={
+          'dev': [
+              'ipdb==0.11',
+              'pylint==2.5.3',
+          ]
+      },
       entry_points='''
           [console_scripts]
           tap-google-search-console=tap_google_search_console:main

--- a/tap_google_search_console/sync.py
+++ b/tap_google_search_console/sync.py
@@ -230,7 +230,8 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
         for record in transformed_data:
             for key in id_fields:
                 if not record.get(key):
-                    raise ValueError('Missing key {} in record: {}'.format(key, record))
+                    primary_keys_only = { id_field: record.get(id_field) for id_field in id_fields }
+                    raise ValueError('Missing key {} in record with primary keys {}'.format(key, primary_keys_only))
         batch_count = len(transformed_data)
 
         # Process records and get the max_bookmark_value and record_count for the set of records

--- a/tap_google_search_console/sync.py
+++ b/tap_google_search_console/sync.py
@@ -237,7 +237,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
         for record in transformed_data:
             for key in id_fields:
                 if not record.get(key):
-                    LOGGER.info('Missing key {} in record: {}'.format(key, record))
+                    raise ValueError('Missing key {} in record: {}'.format(key, record))
         batch_count = len(transformed_data)
 
         # Process records and get the max_bookmark_value and record_count for the set of records
@@ -269,7 +269,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
 
     # Update the state with the max_bookmark_value for the stream, site, sub_type
     # Reference: https://developers.google.com/webmaster-tools/search-console-api-original/v3/searchanalytics/query
-    # NOTE: Results are sorted by click count descending. 
+    # NOTE: Results are sorted by click count descending.
     #       If two rows have the same click count, they are sorted in an arbitrary way.
     #       Records are NOT sorted in DATE order.
     # THEREFOR: State is updated after ALL pages of data for stream, site, sub_type, date window
@@ -375,7 +375,7 @@ def sync(client, config, catalog, state):
                             site,
                             sub_type,
                             start_date)
-                        
+
                         reports_dttm = strptime_to_utc(reports_dttm_str)
                         if reports_dttm < attribution_start_dttm:
                             start_dttm = reports_dttm

--- a/tap_google_search_console/sync.py
+++ b/tap_google_search_console/sync.py
@@ -31,7 +31,6 @@ def write_record(stream_name, record, time_extracted):
         singer.messages.write_record(stream_name, record, time_extracted=time_extracted)
     except OSError as err:
         LOGGER.error('OS Error writing record for: {}'.format(stream_name))
-        LOGGER.error('record: {}'.format(record))
         LOGGER.error('Error: {}'.format(err))
         raise err
 
@@ -97,12 +96,10 @@ def process_records(catalog, #pylint: disable=too-many-branches
 
                     # Keep only records whose bookmark is after the last_datetime
                     if bookmark_dttm >= last_dttm:
-                        # LOGGER.info('record1: {}'.format(record)) # TESTING, comment out
                         write_record(stream_name, transformed_record, \
                             time_extracted=time_extracted)
                         counter.increment()
                 else:
-                    # LOGGER.info('record2: {}'.format(record)) # TESTING, comment out
                     write_record(stream_name, transformed_record, time_extracted=time_extracted)
                     counter.increment()
 
@@ -217,9 +214,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
             data_dict = {}
             data_dict[data_key] = data_list
             data = data_dict
-        # LOGGER.info('data = {}'.format(data)) # TESTING, comment out
         if data_key in data:
-            # LOGGER.info('Number of raw data records: {}'.format(len(data[data_key])))
             transformed_data = transform_json(
                 data,
                 stream_name,
@@ -227,10 +222,8 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                 site,
                 sub_type,
                 dimensions_list)[data_key]
-            # LOGGER.info('Number of transformed_data records: {}'.format(batch_count))
         else:
             LOGGER.info('Number of raw data records: 0')
-        # LOGGER.info('transformed_data = {}'.format(transformed_data))  # TESTING, comment out
         if not transformed_data or transformed_data is None:
             LOGGER.info('xxx NO TRANSFORMED DATA xxx')
             return 0 # No data results


### PR DESCRIPTION
# Description of change
The tap will fail in the target if the record is missing the key, and this would make it fail much faster. See support ticket https://stitchdata.atlassian.net/browse/SUP-1862

Only worry I have is this was logging the full record, and the exception includes the full record, should I remove that?

# Manual QA steps
 - Ran the cloned connection to reproduce the error, resulting in failing on the first record instead of doing lots of syncing only to fail much later when it gets to the target
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
