### PR TITLE
changed indentation of stream-specific logging information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.9
+  * Indent stream-specific logging to be within the stream's execution block
+
 ## 0.0.8
   * Raise error and fail fast if missing pk in record instead of just logging [#9](https://github.com/singer-io/tap-google-search-console/pull/9)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-google-search-console',
-      version='0.0.8',
+      version='0.0.9',
       description='Singer.io tap for extracting data from the Google Search Console API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_google_search_console/sync.py
+++ b/tap_google_search_console/sync.py
@@ -440,9 +440,9 @@ def sync(client, config, catalog, state):
                     # End sub-type loop
                 # End else: Not sitemaps and sites = sc-domain
 
-            LOGGER.info('FINISHED Syncing Stream: {}, Site: {}'.format(stream_name, site))
-            LOGGER.info('  Records Synced for Site: {}'.format(site_total))
-            # End site loop
+                LOGGER.info('FINISHED Syncing Stream: {}, Site: {}'.format(stream_name, site))
+                LOGGER.info('  Records Synced for Site: {}'.format(site_total))
+                # End site loop
 
         LOGGER.info('FINISHED Syncing Stream: {}'.format(stream_name))
         LOGGER.info('  Records Synced for Stream: {}'.format(endpoint_total))


### PR DESCRIPTION
# Description of change
fix for this card:
https://stitchdata.atlassian.net/secure/RapidBoard.jspa?rapidView=23&modal=detail&selectedIssue=SUP-1967
the log line is stream-specific, so it needs to be within the stream while loop
# Manual QA steps
 - cloned connection 289469 (the connection that was seeing the error)
 - ran sync -> ensured that I saw the error
 - made fix -> ensured that error was gone
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
