### PR TITLE
use singer library function to check fields for selection

### DIFF
--- a/tap_google_search_console/sync.py
+++ b/tap_google_search_console/sync.py
@@ -349,7 +349,8 @@ def sync(client, config, catalog, state):
                     mdata = metadata.to_map(stream.metadata)
                     dimensions_all = ['date', 'country', 'device', 'page', 'query']
                     for dim in dimensions_all:
-                        if singer.metadata.get(mdata, ('properties', dim), 'selected'):
+                        if singer.should_sync_field(singer.metadata.get(mdata, ('properties', dim), 'inclusion'),
+                                                    singer.metadata.get(mdata, ('properties', dim), 'selected')):
                             # metadata is selected for the dimension
                             dimensions_list.append(dim)
                     body_params['dimensions'] = dimensions_list


### PR DESCRIPTION
# Description of change

Use singer.should_sync_field and check inclusion metadata to check that we sync the right fields. The tap is correctly writing 'automatic' metadata but it should also be checked when we add items to this list.

# Manual QA steps
 - Verified a 'automatic' inclusion field with false selected still ends up being added to the list.
 
# Risks
 - Low.
 
# Rollback steps
 - revert this branch
