### PR TITLE
Fix state

### DIFF
--- a/tap_google_search_console/client.py
+++ b/tap_google_search_console/client.py
@@ -185,9 +185,13 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
         self.__expires = datetime.utcnow() + timedelta(seconds=data['expires_in'])
         LOGGER.info('Authorized, token expires = {}'.format(self.__expires))
 
-
+    @backoff.on_exception(backoff.constant, 
+                          GoogleForbiddenError,
+                          max_tries=2,  # Only retry once
+                          interval=900,  # Backoff for 15 minutes in case of Quota Exceeded error
+                          jitter=None)  # Interval value not consistent if jitter not None
     @backoff.on_exception(backoff.expo,
-                          (Server5xxError, ConnectionError, Server429Error, GoogleForbiddenError),
+                          (Server5xxError, ConnectionError, Server429Error),
                           max_tries=7,
                           factor=3)
     # Rate Limit:

--- a/tap_google_search_console/client.py
+++ b/tap_google_search_console/client.py
@@ -187,7 +187,7 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
 
 
     @backoff.on_exception(backoff.expo,
-                          (Server5xxError, ConnectionError, Server429Error),
+                          (Server5xxError, ConnectionError, Server429Error, GoogleForbiddenError),
                           max_tries=7,
                           factor=3)
     # Rate Limit:

--- a/tap_google_search_console/sync.py
+++ b/tap_google_search_console/sync.py
@@ -202,6 +202,9 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
         time_extracted = utils.now()
         if not data or data is None or data == {}:
             LOGGER.info('xxx NO DATA xxx')
+
+            if bookmark_field:
+                write_bookmark(state, stream_name, site, sub_type, max_bookmark_value)
             return 0 # No data results
 
         # Transform data with transform_json from transform.py
@@ -226,6 +229,9 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
             LOGGER.info('Number of raw data records: 0')
         if not transformed_data or transformed_data is None:
             LOGGER.info('xxx NO TRANSFORMED DATA xxx')
+
+            if bookmark_field:
+                write_bookmark(state, stream_name, site, sub_type, max_bookmark_value)
             return 0 # No data results
         for record in transformed_data:
             for key in id_fields:


### PR DESCRIPTION
# Description of change
- In trying to validate that commit 1a4e11c2c09e4a1425d61018213193cbff8ce146 was working as intended and writing the state before exiting early, I encountered some rate limiting issues. The Google Search Console API returns a 403 error when there is a "quota exceeded" error instead of a 429 status code. As a result, backoff wasn't actually working and the tap would exit without retrying when hitting the API usage limit. This change adds `GoogleForbiddenError` (403 status code) to the backoff decorator.

# Manual QA steps
 - Test the tap multiple times to exceed API usage limit.
 
# Risks
 - N/A
 
# Rollback steps
 - revert this branch
