### PR TITLE
fix json validator wtih Python3.8 usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json /usr/local/share/virtualenvs/tap-google-search-console/lib/python3.5/site-packages/tap_google_search_console/schemas/*.json
+            stitch-validate-json tap_google_search_console/schemas/*.json
       - run:
           name: 'Integration Tests Setup'
           command: |


### PR DESCRIPTION
# Description of change
Run the json validator against schemas in the checkout code rather than the virtual environment.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
