### PR TITLE
TDL-13530:Discover mode should check permission of token and TDL-13627:Parse error message correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,11 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json tap_google_search_console/schemas/*.json
       - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-google-search-console/bin/activate
+            nosetests tests/unittests/
+      - run:
           name: 'Integration Tests Setup'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-google-search-console/bin/activate
-            nosetests tests/unittests/
+            python -m unittest discover tests/unittests
       - run:
           name: 'Integration Tests Setup'
           command: |

--- a/tap_google_search_console/__init__.py
+++ b/tap_google_search_console/__init__.py
@@ -19,9 +19,10 @@ REQUIRED_CONFIG_KEYS = [
     'user_agent'
 ]
 
-def do_discover():
+def do_discover(client):
 
     LOGGER.info('Starting discover')
+    client.check_sites_access()
     catalog = discover()
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info('Finished discover')
@@ -35,6 +36,7 @@ def main():
     with GoogleClient(parsed_args.config['client_id'],
                       parsed_args.config['client_secret'],
                       parsed_args.config['refresh_token'],
+                      parsed_args.config['site_urls'],
                       parsed_args.config['user_agent']) as client:
 
         state = {}
@@ -42,7 +44,7 @@ def main():
             state = parsed_args.state
 
         if parsed_args.discover:
-            do_discover()
+            do_discover(client)
         elif parsed_args.catalog:
             sync(client=client,
                  config=parsed_args.config,

--- a/tap_google_search_console/client.py
+++ b/tap_google_search_console/client.py
@@ -1,4 +1,6 @@
+import json
 from datetime import datetime, timedelta
+from urllib.parse import quote
 import backoff
 import requests
 
@@ -11,99 +13,144 @@ GOOGLE_TOKEN_URI = 'https://oauth2.googleapis.com/token'
 LOGGER = singer.get_logger()
 
 
-class Server5xxError(Exception):
-    pass
-
-
-class Server429Error(Exception):
-    pass
-
-
 class GoogleError(Exception):
     pass
 
+class Server5xxError(GoogleError):
+    pass
 
 class GoogleBadRequestError(GoogleError):
     pass
 
-
 class GoogleUnauthorizedError(GoogleError):
     pass
-
 
 class GooglePaymentRequiredError(GoogleError):
     pass
 
-
 class GoogleNotFoundError(GoogleError):
     pass
-
 
 class GoogleMethodNotAllowedError(GoogleError):
     pass
 
-
 class GoogleConflictError(GoogleError):
     pass
-
 
 class GoogleGoneError(GoogleError):
     pass
 
-
 class GooglePreconditionFailedError(GoogleError):
     pass
-
 
 class GoogleRequestEntityTooLargeError(GoogleError):
     pass
 
-
 class GoogleRequestedRangeNotSatisfiableError(GoogleError):
     pass
-
 
 class GoogleExpectationFailedError(GoogleError):
     pass
 
-
 class GoogleForbiddenError(GoogleError):
     pass
-
 
 class GoogleUnprocessableEntityError(GoogleError):
     pass
 
-
 class GooglePreconditionRequiredError(GoogleError):
     pass
 
-
-class GoogleInternalServiceError(GoogleError):
+class GoogleRateLimitExceeded(GoogleError):
     pass
 
+class GoogleInternalServiceError(Server5xxError):
+    pass
+
+class GoogleNotImplementedError(Server5xxError):
+    pass
+
+class GoogleServiceUnavailable(Server5xxError):
+    pass
+
+class GoogleQuotaExceededError(GoogleError):
+    pass
 
 # Error Codes: https://developers.google.com/webmaster-tools/search-console-api-original/v3/errors
 ERROR_CODE_EXCEPTION_MAPPING = {
-    400: GoogleBadRequestError,
-    401: GoogleUnauthorizedError,
-    402: GooglePaymentRequiredError,
-    403: GoogleForbiddenError,
-    404: GoogleNotFoundError,
-    405: GoogleMethodNotAllowedError,
-    409: GoogleConflictError,
-    410: GoogleGoneError,
-    412: GooglePreconditionFailedError,
-    413: GoogleRequestEntityTooLargeError,
-    416: GoogleRequestedRangeNotSatisfiableError,
-    417: GoogleExpectationFailedError,
-    422: GoogleUnprocessableEntityError,
-    428: GooglePreconditionRequiredError,
-    500: GoogleInternalServiceError}
-
-
-def get_exception_for_error_code(error_code):
-    return ERROR_CODE_EXCEPTION_MAPPING.get(error_code, GoogleError)
+    400: {
+        "raise_exception": GoogleBadRequestError,
+        "message": "The request is missing or has bad parameters."
+    },
+    401: {
+        "raise_exception": GoogleUnauthorizedError,
+        "message": "Invalid authorization credentials."
+    },
+    402: {
+        "raise_exception": GooglePaymentRequiredError,
+        "message": "The requested operation requires more resources than the quota allows. Payment is required to complete the operation."
+    },
+    403: {
+        "raise_exception": GoogleForbiddenError,
+        "message": "Invalid authorization credentials or permissions."
+    },
+    404: {
+        "raise_exception": GoogleNotFoundError,
+        "message": "The requested resource does not exist."
+    },
+    405: {
+        "raise_exception": GoogleMethodNotAllowedError,
+        "message": "The HTTP method associated with the request is not supported."
+    },
+    409: {
+        "raise_exception": GoogleConflictError,
+        "message": "The API request cannot be completed because the requested operation would conflict with an existing item."
+    },
+    410: {
+        "raise_exception": GoogleGoneError,
+        "message": "The requested resource is permanently unavailable."
+    },
+    412: {
+        "raise_exception": GooglePreconditionFailedError,
+        "message": "The condition set in the request's If-Match or If-None-Match HTTP request header was not met."
+    },
+    413: {
+        "raise_exception": GoogleRequestEntityTooLargeError,
+        "message": "The request is too large."
+    },
+    416: {
+        "raise_exception": GoogleRequestedRangeNotSatisfiableError,
+        "message": "The request specified a range that cannot be satisfied."
+    },
+    417: {
+        "raise_exception": GoogleExpectationFailedError,
+        "message": "A client expectation cannot be met by the server."
+    },
+    422: {
+        "raise_exception": GoogleUnprocessableEntityError,
+        "message": "The request was not able to process right now."
+    },
+    428: {
+        "raise_exception": GooglePreconditionRequiredError,
+        "message": "The request requires a precondition If-Match or If-None-Match which is not provided."
+    },
+    429: {
+        "raise_exception": GoogleRateLimitExceeded,
+        "message": "Rate limit has been exceeded."
+    },
+    500: {
+        "raise_exception": GoogleInternalServiceError,
+        "message": "The request failed due to an internal error."
+    },
+    501: {
+        "raise_exception": GoogleNotImplementedError,
+        "message": "Functionality does not exist."
+    },
+    503: {
+        "raise_exception": GoogleServiceUnavailable,
+        "message": "The API service is currently unavailable."
+    }
+}
 
 def raise_for_error(response):
     try:
@@ -115,33 +162,57 @@ def raise_for_error(response):
                 # There is nothing we can do here since Google has neither sent
                 # us a 2xx response nor a response content.
                 return
-            response = response.json()
-            if ('error' in response) or ('errorCode' in response):
-                message = '%s: %s' % (response.get('error', str(error)),
-                                      response.get('message', 'Unknown Error'))
-                error_code = response.get('error', {}).get('code')
-                ex = get_exception_for_error_code(error_code)
-                raise ex(message)
+            try:
+                response_json = response.json()
+            except Exception:
+                response_json = {}
+
+            error_code = response.status_code
+            error_message = response_json.get("error_description") or response_json.get("error",
+                ERROR_CODE_EXCEPTION_MAPPING.get(error_code,
+                    {})).get("message", "An Unknown Error occurred, please try after some time.")
+
+            message = "HTTP-error-code: {}, Error: {}".format(
+                error_code, error_message)
+
+            # Raise GoogleQuotaExceededError if 403 error code returned due to QuotaExceeded
+            response_error = json.dumps(response_json.get('error', str(error)))
+            if error_code == 403 and "quotaExceeded" in response_error:
+                ex = GoogleQuotaExceededError
             else:
-                raise GoogleError(error)
+                ex = ERROR_CODE_EXCEPTION_MAPPING.get(error_code, {}).get("raise_exception", GoogleError)
+            raise ex(message) from None
+
         except (ValueError, TypeError):
-            raise GoogleError(error)
+            raise GoogleError(error) from None
 
 class GoogleClient: # pylint: disable=too-many-instance-attributes
     def __init__(self,
                  client_id,
                  client_secret,
                  refresh_token,
+                 site_urls,
                  user_agent=None):
         self.__client_id = client_id
         self.__client_secret = client_secret
         self.__refresh_token = refresh_token
+        self.__site_urls = site_urls
         self.__user_agent = user_agent
         self.__access_token = None
         self.__expires = None
         self.__session = requests.Session()
         self.base_url = None
 
+    def check_sites_access(self):
+        site_list = self.__site_urls.replace(" ", "").split(",")
+
+        for site in site_list:
+            site_encoded = quote(site, safe='')
+
+            #Sample query API for check site access
+            path = 'sites/{}/searchAnalytics/query'.format(site_encoded)
+            body = {'startDate': '2021-04-01', 'endDate': '2021-05-01'}
+            self.post(path=path, data=json.dumps(body))
 
     def __enter__(self):
         self.get_access_token()
@@ -174,9 +245,6 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
                 'refresh_token': self.__refresh_token,
             })
 
-        if response.status_code >= 500:
-            raise Server5xxError()
-
         if response.status_code != 200:
             raise_for_error(response)
 
@@ -185,13 +253,13 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
         self.__expires = datetime.utcnow() + timedelta(seconds=data['expires_in'])
         LOGGER.info('Authorized, token expires = {}'.format(self.__expires))
 
-    @backoff.on_exception(backoff.constant, 
-                          GoogleForbiddenError,
+    @backoff.on_exception(backoff.constant,
+                          GoogleQuotaExceededError,
                           max_tries=2,  # Only retry once
                           interval=900,  # Backoff for 15 minutes in case of Quota Exceeded error
                           jitter=None)  # Interval value not consistent if jitter not None
     @backoff.on_exception(backoff.expo,
-                          (Server5xxError, ConnectionError, Server429Error),
+                          (Server5xxError, ConnectionError, GoogleRateLimitExceeded),
                           max_tries=7,
                           factor=3)
     # Rate Limit:
@@ -227,14 +295,6 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
         with metrics.http_request_timer(endpoint) as timer:
             response = self.__session.request(method, url, **kwargs)
             timer.tags[metrics.Tag.http_status_code] = response.status_code
-
-        if response.status_code >= 500:
-            raise Server5xxError()
-
-        #Use retry functionality in backoff to wait and retry if
-        #response code equals 429 because rate limit has been exceeded
-        if response.status_code == 429:
-            raise Server429Error()
 
         if response.status_code != 200:
             raise_for_error(response)

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -1,0 +1,420 @@
+from unittest import mock
+import tap_google_search_console.client as client
+import unittest
+import requests
+
+class Mockresponse:
+    def __init__(self, status_code, json, raise_error, text=None):
+        self.status_code = status_code
+        self.raise_error = raise_error
+        self.text = json
+        self.content = "google search console"
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+
+        raise requests.HTTPError("Sample message")
+
+    def json(self):
+        return self.text
+
+def get_response(status_code, json={}, raise_error=False):
+    return Mockresponse(status_code, json, raise_error)
+
+@mock.patch("requests.Session.request")
+@mock.patch("tap_google_search_console.client.GoogleClient.get_access_token")
+class TestExceptionHandling(unittest.TestCase):
+
+    def test_400_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(400, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleBadRequestError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has bad parameters.")
+
+    def test_401_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(401, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleUnauthorizedError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 401, Error: Invalid authorization credentials.")
+
+    def test_401_error_in_response(self, mocked_access_token, mocked_request):
+        json = {'error': 'invalid_client', 'error_description': 'The OAuth client was not found.'}
+        mocked_request.return_value = get_response(401, json, True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleUnauthorizedError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 401, Error: {}".format(json["error_description"]))
+
+    def test_402_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(402, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GooglePaymentRequiredError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 402, Error: The requested operation requires more resources than the quota allows. Payment is required to complete the operation.")
+
+    def test_403_normal_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(403, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleForbiddenError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 403, Error: Invalid authorization credentials or permissions.")
+
+        # Normal 403 error so no retries
+        self.assertEquals(mocked_request.call_count, 1)
+
+    @mock.patch("time.sleep")
+    def test_403_quota_exceeded_error(self, mocked_sleep, mocked_access_token, mocked_request):
+        json = {
+                "error": {
+                    "code": 403,
+                    "message": "Search Analytics load quota exceeded. Learn about usage limits: https://developers.google.com/webmaster-tools/v3/limits.",
+                    "errors": [{
+                        "message": "Search Analytics load quota exceeded. Learn about usage limits: https://developers.google.com/webmaster-tools/v3/limits.",
+                        "domain": "usageLimits",
+                        "reason": "quotaExceeded"
+                    }]
+                }
+            }
+        mocked_request.return_value = get_response(403, json, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleQuotaExceededError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 403, Error: {}".format(json["error"]["message"]))
+
+        # QuotaExceede 403 error so 2 retries
+        self.assertEquals(mocked_request.call_count, 2)
+        mocked_sleep.assert_called_with(900)
+
+    def test_404_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(404, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleNotFoundError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 404, Error: The requested resource does not exist.")
+
+    def test_404_error_in_response(self, mocked_access_token, mocked_request):
+        json = {
+            'error':
+                {
+                    'code': 404,
+                    'message': "'https://demo310799.000webhostapp1.com' is not a verified Search Console site in this account.",
+                    'errors': [{
+                        'message': "'https://demo310799.000webhostapp1.com' is not a verified Search Console site in this account.",
+                        'domain': 'global',
+                        'reason': 'notFound',
+                        'location': 'siteUrl',
+                        'locationType': 'parameter'}]
+                }
+            }
+        mocked_request.return_value = get_response(404, json, True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleNotFoundError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 404, Error: {}".format(json["error"]["message"]))
+
+    def test_405_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(405, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleMethodNotAllowedError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 405, Error: The HTTP method associated with the request is not supported.")
+
+    def test_409_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(409, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleConflictError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 409, Error: The API request cannot be completed because the requested operation would conflict with an existing item.")
+
+    def test_410_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(410, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleGoneError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 410, Error: The requested resource is permanently unavailable.")
+
+    def test_412_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(412, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GooglePreconditionFailedError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 412, Error: The condition set in the request's If-Match or If-None-Match HTTP request header was not met.")
+
+    def test_413_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(413, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleRequestEntityTooLargeError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 413, Error: The request is too large.")
+
+    def test_416_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(416, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleRequestedRangeNotSatisfiableError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 416, Error: The request specified a range that cannot be satisfied.")
+
+    def test_417_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(417, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleExpectationFailedError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 417, Error: A client expectation cannot be met by the server.")
+
+    def test_422_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(422, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleUnprocessableEntityError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 422, Error: The request was not able to process right now.")
+
+    def test_428_error(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(428, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GooglePreconditionRequiredError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 428, Error: The request requires a precondition If-Match or If-None-Match which is not provided.")
+
+    @mock.patch("time.sleep")
+    def test_429_error(self, mocked_sleep, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(429, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleRateLimitExceeded as e:
+            self.assertEquals(str(e), "HTTP-error-code: 429, Error: Rate limit has been exceeded.")
+
+        # on 429 error function backoff and retries 7 times
+        self.assertEquals(mocked_request.call_count, 7)
+
+    @mock.patch("time.sleep")
+    def test_500_error(self, mocked_sleep, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(500, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleInternalServiceError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 500, Error: The request failed due to an internal error.")
+
+        # on 5xx error function backoff and retries 7 times
+        self.assertEquals(mocked_request.call_count, 7)
+
+    @mock.patch("time.sleep")
+    def test_501_error(self, mocked_sleep, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(501, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleNotImplementedError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 501, Error: Functionality does not exist.")
+
+        # on 5xx error function backoff and retries 7 times
+        self.assertEquals(mocked_request.call_count, 7)
+
+    @mock.patch("time.sleep")
+    def test_503_error(self, mocked_sleep, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(503, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.request("")
+        except client.GoogleServiceUnavailable as e:
+            self.assertEquals(str(e), "HTTP-error-code: 503, Error: The API service is currently unavailable.")
+
+        # on 5xx error function backoff and retries 7 times
+        self.assertEquals(mocked_request.call_count, 7)
+
+    def test_200_success(self, mocked_access_token, mocked_request):
+        json = {"key": "value", "tap": "google search console"}
+        mocked_request.return_value = get_response(200, json)
+        google_client = client.GoogleClient("", "", "", "")
+
+        response = google_client.request("")
+        self.assertEquals(json, response)
+
+@mock.patch("requests.Session.post")
+class TestAccessToken(unittest.TestCase):
+
+    def test_400_error(self, mocked_request):
+        mocked_request.return_value = get_response(400, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleBadRequestError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 400, Error: The request is missing or has bad parameters.")
+
+    def test_401_error(self, mocked_request):
+        mocked_request.return_value = get_response(401, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleUnauthorizedError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 401, Error: Invalid authorization credentials.")
+
+    def test_402_error(self, mocked_request):
+        mocked_request.return_value = get_response(402, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GooglePaymentRequiredError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 402, Error: The requested operation requires more resources than the quota allows. Payment is required to complete the operation.")
+
+    def test_403_error(self, mocked_request):
+        mocked_request.return_value = get_response(403, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleForbiddenError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 403, Error: Invalid authorization credentials or permissions.")
+
+    def test_404_error(self, mocked_request):
+        mocked_request.return_value = get_response(404, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleNotFoundError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 404, Error: The requested resource does not exist.")
+
+    def test_405_error(self, mocked_request):
+        mocked_request.return_value = get_response(405, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleMethodNotAllowedError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 405, Error: The HTTP method associated with the request is not supported.")
+
+    def test_409_error(self, mocked_request):
+        mocked_request.return_value = get_response(409, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleConflictError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 409, Error: The API request cannot be completed because the requested operation would conflict with an existing item.")
+
+    def test_410_error(self, mocked_request):
+        mocked_request.return_value = get_response(410, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleGoneError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 410, Error: The requested resource is permanently unavailable.")
+
+    def test_412_error(self, mocked_request):
+        mocked_request.return_value = get_response(412, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GooglePreconditionFailedError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 412, Error: The condition set in the request's If-Match or If-None-Match HTTP request header was not met.")
+
+    def test_413_error(self, mocked_request):
+        mocked_request.return_value = get_response(413, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleRequestEntityTooLargeError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 413, Error: The request is too large.")
+
+    def test_416_error(self, mocked_request):
+        mocked_request.return_value = get_response(416, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleRequestedRangeNotSatisfiableError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 416, Error: The request specified a range that cannot be satisfied.")
+
+    def test_417_error(self, mocked_request):
+        mocked_request.return_value = get_response(417, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleExpectationFailedError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 417, Error: A client expectation cannot be met by the server.")
+
+    def test_422_error(self, mocked_request):
+        mocked_request.return_value = get_response(422, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleUnprocessableEntityError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 422, Error: The request was not able to process right now.")
+
+    def test_428_error(self, mocked_request):
+        mocked_request.return_value = get_response(428, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GooglePreconditionRequiredError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 428, Error: The request requires a precondition If-Match or If-None-Match which is not provided.")
+
+    def test_429_error(self, mocked_request):
+        mocked_request.return_value = get_response(429, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleRateLimitExceeded as e:
+            self.assertEquals(str(e), "HTTP-error-code: 429, Error: Rate limit has been exceeded.")
+
+    @mock.patch("time.sleep")
+    def test_500_error(self, mocked_sleep, mocked_request):
+        mocked_request.return_value = get_response(500, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleInternalServiceError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 500, Error: The request failed due to an internal error.")
+
+        # on 5xx error function backoff and retries 5 times
+        self.assertEquals(mocked_request.call_count, 5)
+
+    @mock.patch("time.sleep")
+    def test_501_error(self, mocked_sleep, mocked_request):
+        mocked_request.return_value = get_response(501, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleNotImplementedError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 501, Error: Functionality does not exist.")
+
+        # on 5xx error function backoff and retries 5 times
+        self.assertEquals(mocked_request.call_count, 5)
+
+    @mock.patch("time.sleep")
+    def test_503_error(self, mocked_sleep, mocked_request):
+        mocked_request.return_value = get_response(503, raise_error = True)
+        google_client = client.GoogleClient("", "", "", "")
+        try:
+            google_client.get_access_token()
+        except client.GoogleServiceUnavailable as e:
+            self.assertEquals(str(e), "HTTP-error-code: 503, Error: The API service is currently unavailable.")
+
+        # on 5xx error function backoff and retries 5 times
+        self.assertEquals(mocked_request.call_count, 5)
+
+    @mock.patch("tap_google_search_console.client.LOGGER.info")
+    def test_200_success(self, mocked_logger, mocked_request):
+        json = {"access_token": "googlesearchconsole", "expires_in": 1}
+        mocked_request.return_value = get_response(200, json=json)
+        google_client = client.GoogleClient("", "", "", "")
+
+        google_client.get_access_token()
+        self.assertEquals(mocked_logger.call_count, 1)

--- a/tests/unittests/test_sites_access.py
+++ b/tests/unittests/test_sites_access.py
@@ -1,0 +1,80 @@
+import tap_google_search_console.client as client_
+import unittest
+import requests
+from unittest import mock
+
+def get_mock_http_response(status_code, contents):
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = contents.encode()
+    return response
+
+@mock.patch("requests.Session.request")
+@mock.patch("tap_google_search_console.client.GoogleClient.get_access_token")
+class TestCredentials(unittest.TestCase):
+
+    def test_sites_access_valid(self, mocked_get_token, mocked_request):
+        # Access token is valid and enough permission for site access
+        mocked_request.return_value = get_mock_http_response(200, '{"success": {"code": 200}}')
+        sites = "https://example.com, https://www.example.com"
+        gsc_client = client_.GoogleClient('', '', '', sites, '')
+        gsc_client.check_sites_access()
+        self.assertEqual(mocked_request.call_count, 2)
+
+    def test_sites_invalid_creds(self, mocked_get_token, mocked_request):
+        # Access token is invalid for site query request
+        mocked_request.return_value = get_mock_http_response(401, '{"error": {"code": 401}}')
+        sites = "https://example.com, https://www.example.com"
+        gsc_client = client_.GoogleClient('', '', '', sites, '')
+        with self.assertRaises(client_.GoogleUnauthorizedError):
+            gsc_client.check_sites_access()
+        self.assertEqual(mocked_request.call_count, 1)
+
+    def test_sites_access_forbidden(self, mocked_get_token, mocked_request):
+        # Site is not valid or not accessible for user
+        mocked_request.return_value = get_mock_http_response(403, '{"error": {"code": 403}}')
+        sites = "https://example.com"
+        gsc_client = client_.GoogleClient('', '', '', sites, '')
+        with self.assertRaises(client_.GoogleForbiddenError):
+            gsc_client.check_sites_access()
+        self.assertEqual(mocked_request.call_count, 1)
+
+@mock.patch("requests.Session.post")
+@mock.patch("requests.Session.request")
+class TestSiteAccessTokenScenario(unittest.TestCase):
+
+    def test_sites_access_token_success(self, mocked_data_request, mocked_access_token_post_request):
+        # Valid credentials for access token request
+        mocked_access_token_post_request.return_value = get_mock_http_response(200, '{"access_token" : "abc", "expires_in" : 100}')
+        mocked_data_request.return_value = get_mock_http_response(200, '{"success": {"code": 200}}')
+        sites = "https://example.com"
+        gsc_client = client_.GoogleClient('', '', '', sites, '')
+        gsc_client.check_sites_access()
+        self.assertEqual(mocked_data_request.call_count, 1)
+
+    def test_sites_access_token_failed_401(self, mocked_data_request, mocked_access_token_post_request):
+        # Invalid client id or secret for access token request
+        mocked_access_token_post_request.return_value = get_mock_http_response(401, '{"error": {"code": 401}}')
+        sites = "https://example.com"
+        gsc_client = client_.GoogleClient('', '', '', sites, '')
+        with self.assertRaises(client_.GoogleUnauthorizedError):
+            gsc_client.check_sites_access()
+        self.assertEqual(mocked_data_request.call_count, 0)
+
+    def test_sites_access_token_failed_400(self, mocked_data_request, mocked_access_token_post_request):
+        # Invalid refresh token for access token request
+        mocked_access_token_post_request.return_value = get_mock_http_response(400, '{"error": {"code": 400}}')
+        sites = "https://example.com"
+        gsc_client = client_.GoogleClient('', '', '', sites, '')
+        with self.assertRaises(client_.GoogleBadRequestError):
+            gsc_client.check_sites_access()
+        self.assertEqual(mocked_data_request.call_count, 0)
+
+@mock.patch("tap_google_search_console.client.GoogleClient.post")
+class TestSitesAccessCallCount(unittest.TestCase):
+
+    def test_site_access_call_count(self, mocked_post_request):
+        sites = "https://example.com, https://www.example.com, http://example.com, http://www.example.com, sc-domain:example.com"
+        gsc_client = client_.GoogleClient('', '', '', sites, '')
+        gsc_client.check_sites_access()
+        self.assertEquals(mocked_post_request.call_count, 5)


### PR DESCRIPTION
# Description of change
TDL-13530:Discover mode should check the permission of the token.
- Added API call with simple SearchAnalytics query for a list of site_urls during discover mode.
- Backoff of 900 seconds will be only applied if 403 is triggered due to QuotaExceeded error and no backoff for 403 for others reasons.

TDL-13627:Parse error message correctly and add proper exception handling.([Doc Link](https://talend365-my.sharepoint.com/:w:/g/personal/schovatiya_talend_com/EWs84LxVigZJpdVKS6WhuqQBvg1UZMqLGByqGyl6FFzzNQ?e=9gpwrl))

# Manual QA steps
 - Verified that one request with the simple query is made during discover mode for all site URLs.
 -  Verified that exception is thrown during discover mode if a request is failed with error code.
 - Manually created desired response and verified that tap is retrying after 900 seconds only if 403 is returned due to QuotaExceeded error.
 - Verified that tap is not retrying for 403 error with limited permission reason.
 - Verified that no exception during parsing error message from the response during failed API request.
 - Run unit tests for permission checking and exception handling with different scenarios.
 
# Risks
 - No risk
 
# Rollback steps
 - revert this branch
