### PR TITLE
TDL-6750: Move test from tap-tester, increase coverage and best pract…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,24 +25,19 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json tap_google_search_console/schemas/*.json
       - run:
-          name: 'Integration Tests Setup'
+          name: 'Integration Tests'
           command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
-      # TODO: Move tests over from tap-tester repo, leaving out for now
-      #       (https://stitchdata.atlassian.net/browse/SRCE-4768)
-      #- run:
-      #    name: 'Integration Tests'
-      #    command: |
-      #      source dev_env.sh
-      #      source /usr/local/share/virtualenvs/tap-tester/bin/activate
-      #      PYTHONPATH=$PYTHONPATH:/usr/local/share/virtualenvs/tap-google-search-console/lib/python3.5/site-packages/ \
-      #      run-test --tap=tap-google-search-console \
-      #               --target=target-stitch \
-      #               --orchestrator=stitch-orchestrator \
-      #               --email=harrison+sandboxtest@stitchdata.com \
-      #               --password=$SANDBOX_PASSWORD \
-      #               --client-id=50 \
-      #               tests/tap_combined_test.py
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            run-test --tap=tap-google-search-console \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$SANDBOX_PASSWORD \
+                     --client-id=50 \
+                     --token=$STITCH_API_TOKEN \
+                     tests
 workflows:
   version: 2
   commit:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-google-search-console',
       install_requires=[
           'backoff==1.8.0',
           'requests==2.22.0',
-          'singer-python==5.8.1'
+          'singer-python==5.12.1'
       ],
       extras_require={
           'dev': [

--- a/tests/base.py
+++ b/tests/base.py
@@ -48,7 +48,7 @@ class GoogleSearchConsoleBaseTest(unittest.TestCase):
     def get_properties(self, original: bool = True):
         """Configuration properties required for the tap."""
         properties_dict = {
-            'start_date': dt.strftime(dt.utcnow()-timedelta(days=15), self.START_DATE_FORMAT),
+            'start_date': dt.strftime(dt.utcnow()-timedelta(days=14), self.START_DATE_FORMAT),
         }
         props = self.properties
         for prop in props:

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,302 @@
+import unittest
+import os
+from datetime import timedelta
+from datetime import datetime as dt
+import time
+
+import singer
+from tap_tester import connections, menagerie, runner
+
+class GoogleSearchConsoleBaseTest(unittest.TestCase):
+    """
+    Setup expectations for test sub classes.
+    Metadata describing streams.
+    A bunch of shared methods that are used in tap-tester tests.
+    Shared tap-specific methods (as needed).
+    """
+    AUTOMATIC_FIELDS = "automatic"
+    REPLICATION_KEYS = "valid-replication-keys"
+    PRIMARY_KEYS = "table-key-properties"
+    REPLICATION_METHOD = "forced-replication-method"
+    INCREMENTAL = "INCREMENTAL"
+    FULL_TABLE = "FULL_TABLE"
+    START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
+    DATETIME_FMT = {
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S.000000Z"
+    }
+    start_date = ""
+    properties = {
+        "client_id": "TAP_GOOGLE_SEARCH_CONSOLE_CLIENT_ID",
+	    "site_urls": "TAP_GOOGLE_SEARCH_CONSOLE_SITE_URLS"
+    }
+    credentials = {
+        "client_secret": "TAP_GOOGLE_SEARCH_CONSOLE_CLIENT_SECRET",
+        "refresh_token": "TAP_GOOGLE_SEARCH_CONSOLE_REFRESH_TOKEN"
+    }
+
+
+    @staticmethod
+    def tap_name():
+        """The name of the tap"""
+        return 'tap-google-search-console'
+
+    @staticmethod
+    def get_type():
+        return 'platform.google-search-console'
+
+    def get_properties(self, original: bool = True):
+        """Configuration properties required for the tap."""
+        properties_dict = {
+            'start_date': dt.strftime(dt.utcnow()-timedelta(days=15), self.START_DATE_FORMAT),
+        }
+        props = self.properties
+        for prop in props:
+            properties_dict[prop] = os.getenv(props[prop])
+
+        if original:
+            return properties_dict
+
+        properties_dict["start_date"] = self.start_date
+        return properties_dict
+
+    def get_credentials(self):
+        """Authentication information for the test account. Username is expected as a property."""
+        credentials_dict = {}
+        creds = self.credentials
+        for cred in creds:
+            credentials_dict[cred] = os.getenv(creds[cred])
+
+        return credentials_dict
+
+    def expected_metadata(self):
+        """The expected primary key of the streams"""
+        return{
+            "sites": {
+                self.PRIMARY_KEYS: {"site_url"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+            },
+            "sitemaps": {
+                self.PRIMARY_KEYS: {"site_url", "path", "last_submitted"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+            },
+            "performance_report_custom": {
+                self.PRIMARY_KEYS: {"site_url", "search_type", "date", "dimensions_hash_key"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"date"}
+            },
+            "performance_report_date": {
+                self.PRIMARY_KEYS: {"site_url", "search_type", "date"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"date"}
+            },
+            "performance_report_country": {
+                self.PRIMARY_KEYS: {"site_url", "search_type", "date", "country"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"date"}
+            },
+            "performance_report_device": {
+                self.PRIMARY_KEYS: {"site_url", "search_type", "date", "device"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"date"}
+            },
+            "performance_report_page": {
+                self.PRIMARY_KEYS: {"site_url", "search_type", "date", "page"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"date", "page"}
+            },
+            "performance_report_query": {
+                self.PRIMARY_KEYS: {"site_url", "search_type", "date", "query"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"date"}
+            }
+        }
+
+    def expected_streams(self):
+        """A set of expected stream names"""
+        return set(self.expected_metadata().keys())
+
+    def expected_primary_keys(self):
+        """return a dictionary with key of table name and value as a set of primary key fields"""
+        return {table: properties.get(self.PRIMARY_KEYS, set())
+                for table, properties
+                in self.expected_metadata().items()}
+
+    def expected_replication_keys(self):
+        """return a dictionary with key of table name and value as a set of replication key fields"""
+        return {table: properties.get(self.REPLICATION_KEYS, set())
+                for table, properties
+                in self.expected_metadata().items()}
+
+    def expected_automatic_fields(self):
+        """return a dictionary with key of table name and set of value of automatic(primary key and bookmark field) fields"""
+        auto_fields = {}
+        for k, v in self.expected_metadata().items():
+            auto_fields[k] = v.get(self.PRIMARY_KEYS, set()) |  v.get(self.REPLICATION_KEYS, set())
+        return auto_fields
+
+    def expected_replication_method(self):
+        """return a dictionary with key of table name and value of replication method"""
+        return {table: properties.get(self.REPLICATION_METHOD, None)
+                for table, properties
+                in self.expected_metadata().items()}
+
+    def setUp(self):
+        missing_envs = []
+        props = self.properties
+        creds = self.credentials
+
+        for prop in props:
+            if os.getenv(props[prop]) == None:
+                missing_envs.append(prop)
+        for cred in creds:
+            if os.getenv(creds[cred]) == None:
+                missing_envs.append(cred)
+
+        if len(missing_envs) != 0:
+            raise Exception("set " + ", ".join(missing_envs))
+
+     #########################
+    #   Helper Methods      #
+    #########################
+
+    def run_and_verify_check_mode(self, conn_id):
+        """
+        Run the tap in check mode and verify it succeeds.
+        This should be ran prior to field selection and initial sync.
+        Return the connection id and found catalogs from menagerie.
+        """
+        # run in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        # verify check exit codes
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+
+        found_catalog_names = set(map(lambda c: c['stream_name'], found_catalogs))
+        print(found_catalog_names)
+        self.assertSetEqual(self.expected_streams(), found_catalog_names, msg="discovered schemas do not match")
+        print("discovered schemas are OK")
+
+        return found_catalogs
+
+    def run_and_verify_sync(self, conn_id):
+        """
+        Run a sync job and make sure it exited properly.
+        Return a dictionary with keys of streams synced
+        and values of records synced for each stream
+        """
+        # Run a sync job using orchestrator
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        # Verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        # Verify actual rows were synced
+        sync_record_count = runner.examine_target_output_file(
+            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+        self.assertGreater(
+            sum(sync_record_count.values()), 0,
+            msg="failed to replicate any data: {}".format(sync_record_count)
+        )
+        print("total replicated row count: {}".format(sum(sync_record_count.values())))
+
+        return sync_record_count
+
+    def perform_and_verify_table_and_field_selection(self,
+                                                     conn_id,
+                                                     test_catalogs,
+                                                     select_all_fields=True):
+        """
+        Perform table and field selection based off of the streams to select
+        set and field selection parameters.
+        Verify this results in the expected streams selected and all or no
+        fields selected for those streams.
+        """
+
+        # Select all available fields or select no fields from all testable streams
+        self.select_all_streams_and_fields(
+            conn_id=conn_id, catalogs=test_catalogs, select_all_fields=select_all_fields
+        )
+
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        # Ensure our selection affects the catalog
+        expected_selected = [tc.get('stream_name') for tc in test_catalogs]
+        for cat in catalogs:
+            catalog_entry = menagerie.get_annotated_schema(conn_id, cat['stream_id'])
+
+            # Verify all testable streams are selected
+            selected = catalog_entry.get('annotated-schema').get('selected')
+            print("Validating selection on {}: {}".format(cat['stream_name'], selected))
+            if cat['stream_name'] not in expected_selected:
+                self.assertFalse(selected, msg="Stream selected, but not testable.")
+                continue # Skip remaining assertions if we aren't selecting this stream
+            self.assertTrue(selected, msg="Stream not selected.")
+
+            if select_all_fields:
+                # Verify all fields within each selected stream are selected
+                for field, field_props in catalog_entry.get('annotated-schema').get('properties').items():
+                    field_selected = field_props.get('selected')
+                    print("\tValidating selection on {}.{}: {}".format(
+                        cat['stream_name'], field, field_selected))
+                    self.assertTrue(field_selected, msg="Field not selected.")
+            else:
+                # Verify only automatic fields are selected
+                expected_automatic_fields = self.expected_automatic_fields().get(cat['stream_name'])
+                selected_fields = self.get_selected_fields_from_metadata(catalog_entry['metadata'])
+                self.assertEqual(expected_automatic_fields, selected_fields)
+
+    @staticmethod
+    def get_selected_fields_from_metadata(metadata):
+        selected_fields = set()
+        for field in metadata:
+            is_field_metadata = len(field['breadcrumb']) > 1
+            inclusion_automatic_or_selected = (
+                field['metadata']['selected'] is True or \
+                field['metadata']['inclusion'] == 'automatic'
+            )
+            if is_field_metadata and inclusion_automatic_or_selected:
+                selected_fields.add(field['breadcrumb'][1])
+        return selected_fields
+
+
+    @staticmethod
+    def select_all_streams_and_fields(conn_id, catalogs, select_all_fields: bool = True):
+        """Select all streams and all fields within streams"""
+        for catalog in catalogs:
+            schema = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
+
+            non_selected_properties = []
+            if not select_all_fields:
+                # get a list of all properties so that none are selected
+                non_selected_properties = schema.get('annotated-schema', {}).get(
+                    'properties', {}).keys()
+
+            connections.select_catalog_and_fields_via_metadata(
+                conn_id, catalog, schema, [], non_selected_properties)
+
+    def timedelta_formatted(self, dtime, days=0):
+        date_stripped = dt.strptime(dtime, self.START_DATE_FORMAT)
+        return_date = date_stripped + timedelta(days=days)
+
+        return dt.strftime(return_date, self.START_DATE_FORMAT)
+
+    ##########################################################################
+    ### Tap Specific Methods
+    ##########################################################################
+
+    def is_incremental(self, stream):
+        return self.expected_metadata()[stream][self.REPLICATION_METHOD] == self.INCREMENTAL
+
+    def dt_to_ts(self, dtime):
+        for date_format in self.DATETIME_FMT:
+            try:
+                date_stripped = int(time.mktime(dt.strptime(dtime, date_format).timetuple()))
+                return date_stripped
+            except ValueError:
+                continue

--- a/tests/test_gsc_discovery.py
+++ b/tests/test_gsc_discovery.py
@@ -1,0 +1,117 @@
+"""Test tap discovery mode and metadata."""
+import re
+
+from tap_tester import menagerie, connections
+
+from base import GoogleSearchConsoleBaseTest
+
+class GoogleSearchConsoleDiscovery(GoogleSearchConsoleBaseTest):
+
+    def name(self):
+        return "tap_tester_google_search_console_discovery_test"
+
+    def test_run(self):
+        """
+        Testing that discovery creates the appropriate catalog with valid metadata.
+        • Verify number of actual streams discovered match expected
+        • Verify the stream names discovered were what we expect
+        • Verify stream names follow naming convention
+          streams should only have lowercase alphas and underscores
+        • verify there is only 1 top level breadcrumb
+        • verify replication key(s)
+        • verify primary key(s)
+        • verify that if there is a replication key we are doing INCREMENTAL otherwise FULL
+        • verify the actual replication matches our expected replication method
+        • verify that primary, replication and foreign keys
+          are given the inclusion of automatic.
+        • verify that all other fields have inclusion of available metadata.
+        """
+        streams_to_test = self.expected_streams()
+
+        conn_id = connections.ensure_connection(self)
+
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+        # Verify stream names follow naming convention
+        # streams should only have lowercase alphas and underscores
+        found_catalog_names = {c['tap_stream_id'] for c in found_catalogs}
+        self.assertTrue(all([re.fullmatch(r"[a-z_]+",  name) for name in found_catalog_names]),
+                        msg="One or more streams don't follow standard naming")
+
+        for stream in streams_to_test:
+            with self.subTest(stream=stream):
+
+                # Verify ensure the catalog is found for a given stream
+                catalog = next(iter([catalog for catalog in found_catalogs
+                                     if catalog["stream_name"] == stream]))
+                self.assertIsNotNone(catalog)
+
+                # collecting expected values
+                expected_primary_keys = self.expected_primary_keys()[stream]
+                expected_replication_keys = self.expected_replication_keys()[stream]
+                expected_automatic_fields = expected_primary_keys | expected_replication_keys
+                expected_replication_method = self.expected_replication_method()[stream]
+
+                # collecting actual values...
+                schema_and_metadata = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
+                metadata = schema_and_metadata["metadata"]
+                stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+                actual_primary_keys = set(
+                    stream_properties[0].get(
+                        "metadata", {self.PRIMARY_KEYS: []}).get(self.PRIMARY_KEYS, [])
+                )
+                actual_replication_keys = set(
+                    stream_properties[0].get(
+                        "metadata", {self.REPLICATION_KEYS: []}).get(self.REPLICATION_KEYS, [])
+                )
+
+                actual_replication_method = stream_properties[0].get(
+                    "metadata", {self.REPLICATION_METHOD: None}).get(self.REPLICATION_METHOD)
+
+                actual_automatic_fields = set(
+                    item.get("breadcrumb", ["properties", None])[1] for item in metadata
+                    if item.get("metadata").get("inclusion") == "automatic"
+                )
+
+                ##########################################################################
+                ### metadata assertions
+                ##########################################################################
+
+                # verify there is only 1 top level breadcrumb in metadata
+                self.assertTrue(len(stream_properties) == 1,
+                                msg="There is NOT only one top level breadcrumb for {}".format(stream) + \
+                                "\nstream_properties | {}".format(stream_properties))
+
+                # verify replication key(s) match expectations
+                self.assertSetEqual(
+                    expected_replication_keys, actual_replication_keys
+                )
+
+                # verify primary key(s) match expectations
+                self.assertSetEqual(
+                    expected_primary_keys, actual_primary_keys,
+                )
+                
+                # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL
+                if actual_replication_keys:
+                    self.assertEqual(self.INCREMENTAL, actual_replication_method)
+                else:
+                    self.assertEqual(self.FULL_TABLE, actual_replication_method)
+
+                # verify the replication method matches our expectations
+                self.assertEqual(
+                    expected_replication_method, actual_replication_method
+                )
+
+                # verify that primary keys and replication keys
+                # are given the inclusion of automatic in metadata.
+                self.assertSetEqual(expected_automatic_fields, actual_automatic_fields)
+
+                # verify that all other fields have inclusion of available
+                # This assumes there are no unsupported fields for SaaS sources
+                self.assertTrue(
+                    all({item.get("metadata").get("inclusion") == "available"
+                         for item in metadata
+                         if item.get("breadcrumb", []) != []
+                         and item.get("breadcrumb", ["properties", None])[1]
+                         not in actual_automatic_fields}),
+                    msg="Not all non key properties are set to available in metadata")

--- a/tests/test_gsc_pagination_test.py
+++ b/tests/test_gsc_pagination_test.py
@@ -14,7 +14,7 @@ class PaginationTest(GoogleSearchConsoleBaseTest):
         conn_id = connections.ensure_connection(self)
 
         # Checking pagination for "performance_report_custom" stream
-        expected_streams = ["performance_report_custom"]
+        expected_streams = ["performance_report_page"]
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
         # table and field selection

--- a/tests/test_gsc_pagination_test.py
+++ b/tests/test_gsc_pagination_test.py
@@ -1,0 +1,52 @@
+from tap_tester import runner, connections
+
+from base import GoogleSearchConsoleBaseTest
+
+class PaginationTest(GoogleSearchConsoleBaseTest):
+
+    @staticmethod
+    def name():
+        return "tap_tester_google_search_console_pagination_test"
+
+    def test_run(self):
+        # page size for "performance_report_custom"
+        page_size = 10000
+        conn_id = connections.ensure_connection(self)
+
+        # Checking pagination for "performance_report_custom" stream
+        expected_streams = ["performance_report_custom"]
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # table and field selection
+        test_catalogs = [catalog for catalog in found_catalogs
+                                      if catalog.get('stream_name') in expected_streams]
+
+        self.perform_and_verify_table_and_field_selection(conn_id, test_catalogs)
+
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
+
+        synced_records = runner.get_records_from_target_output()
+
+        for stream in expected_streams:
+            with self.subTest(stream=stream):
+                # expected values
+                expected_primary_keys = self.expected_primary_keys()
+
+                # collect information for assertions from syncs 1 & 2 base on expected values
+                record_count_sync = record_count_by_stream.get(stream, 0)
+                primary_keys_list = [(message.get('data').get(expected_pk) for expected_pk in expected_primary_keys)
+                                       for message in synced_records.get(stream).get('messages')
+                                       if message.get('action') == 'upsert']
+
+                # verify records are more than page size so multiple page is working
+                self.assertGreater(record_count_sync, page_size)
+
+                if record_count_sync > page_size:
+                    primary_keys_list_1 = primary_keys_list[:page_size]
+                    primary_keys_list_2 = primary_keys_list[page_size:2*page_size]
+
+                    primary_keys_page_1 = set(primary_keys_list_1)
+                    primary_keys_page_2 = set(primary_keys_list_2)
+
+                    # Verify by private keys that data is unique for page
+                    self.assertTrue(primary_keys_page_1.isdisjoint(primary_keys_page_2))

--- a/tests/test_gsc_start_date.py
+++ b/tests/test_gsc_start_date.py
@@ -33,7 +33,7 @@ class GoogleSearchConsoleStartDateTest(GoogleSearchConsoleBaseTest):
         ##########################################################################
 
         # instantiate connection
-        conn_id_1 = connections.ensure_connection(self)
+        conn_id_1 = connections.ensure_connection(self, original_properties=False)
 
         # run check mode
         found_catalogs_1 = self.run_and_verify_check_mode(conn_id_1)

--- a/tests/test_gsc_start_date.py
+++ b/tests/test_gsc_start_date.py
@@ -17,15 +17,16 @@ class GoogleSearchConsoleStartDateTest(GoogleSearchConsoleBaseTest):
     def test_run(self):
         """Instantiate start date according to the desired data set and run the test"""
 
-        self.start_date_1 = self.get_properties().get('start_date')
-        self.start_date_2 = self.timedelta_formatted(self.start_date_1, days=1)
+        self.start_date_2 = self.get_properties().get('start_date')
+        self.start_date_1 = self.timedelta_formatted(self.start_date_2, days=-1)
 
         start_date_1_epoch = self.dt_to_ts(self.start_date_1)
         start_date_2_epoch = self.dt_to_ts(self.start_date_2)
 
         self.start_date = self.start_date_1
 
-        expected_streams = self.expected_streams()
+        # Select fewer stream as tests take longer to complete
+        expected_streams = ['sites', 'sitemaps', 'performance_report_date', 'performance_report_device']
 
         ##########################################################################
         ### First Sync

--- a/tests/test_gsc_start_date.py
+++ b/tests/test_gsc_start_date.py
@@ -1,0 +1,132 @@
+import os
+
+from tap_tester import connections, runner
+
+from base import GoogleSearchConsoleBaseTest
+
+
+class GoogleSearchConsoleStartDateTest(GoogleSearchConsoleBaseTest):
+
+    start_date_1 = ""
+    start_date_2 = ""
+
+    @staticmethod
+    def name():
+        return "tap_tester_google_search_console_start_date_test"
+
+    def test_run(self):
+        """Instantiate start date according to the desired data set and run the test"""
+
+        self.start_date_1 = self.get_properties().get('start_date')
+        self.start_date_2 = self.timedelta_formatted(self.start_date_1, days=1)
+
+        start_date_1_epoch = self.dt_to_ts(self.start_date_1)
+        start_date_2_epoch = self.dt_to_ts(self.start_date_2)
+
+        self.start_date = self.start_date_1
+
+        expected_streams = self.expected_streams()
+
+        ##########################################################################
+        ### First Sync
+        ##########################################################################
+
+        # instantiate connection
+        conn_id_1 = connections.ensure_connection(self)
+
+        # run check mode
+        found_catalogs_1 = self.run_and_verify_check_mode(conn_id_1)
+
+        # table and field selection
+        test_catalogs_1_all_fields = [catalog for catalog in found_catalogs_1
+                                      if catalog.get('stream_name') in expected_streams]
+        self.perform_and_verify_table_and_field_selection(conn_id_1, test_catalogs_1_all_fields, select_all_fields=True)
+
+        # run initial sync
+        record_count_by_stream_1 = self.run_and_verify_sync(conn_id_1)
+        synced_records_1 = runner.get_records_from_target_output()
+
+         ##########################################################################
+        ### Update START DATE Between Syncs
+        ##########################################################################
+
+        print("REPLICATION START DATE CHANGE: {} ===>>> {} ".format(self.start_date, self.start_date_2))
+        self.start_date = self.start_date_2
+
+        ##########################################################################
+        ### Second Sync
+        ##########################################################################
+
+        # create a new connection with the new start_date
+        conn_id_2 = connections.ensure_connection(self, original_properties=False)
+
+        # run check mode
+        found_catalogs_2 = self.run_and_verify_check_mode(conn_id_2)
+
+        # table and field selection
+        test_catalogs_2_all_fields = [catalog for catalog in found_catalogs_2
+                                      if catalog.get('stream_name') in expected_streams]
+        self.perform_and_verify_table_and_field_selection(conn_id_2, test_catalogs_2_all_fields, select_all_fields=True)
+
+        # run sync
+        record_count_by_stream_2 = self.run_and_verify_sync(conn_id_2)
+        synced_records_2 = runner.get_records_from_target_output()
+
+        # Verify the total number of records replicated in sync 1 is greater than the number
+        # of records replicated in sync 2
+        self.assertGreater(sum(record_count_by_stream_1.values()), sum(record_count_by_stream_2.values()))
+
+        for stream in expected_streams:
+
+            with self.subTest(stream=stream):
+
+                # expected values
+                expected_primary_keys = self.expected_primary_keys()[stream]
+                expected_bookmark_keys = self.expected_replication_keys()[stream]
+
+                # collect information for assertions from syncs 1 & 2 base on expected values
+                record_count_sync_1 = record_count_by_stream_1.get(stream, 0)
+                record_count_sync_2 = record_count_by_stream_2.get(stream, 0)
+                primary_keys_list_1 = [tuple(message.get('data').get(expected_pk) for expected_pk in expected_primary_keys)
+                                       for message in synced_records_1.get(stream).get('messages')
+                                       if message.get('action') == 'upsert']
+                primary_keys_list_2 = [tuple(message.get('data').get(expected_pk) for expected_pk in expected_primary_keys)
+                                       for message in synced_records_2.get(stream).get('messages')
+                                       if message.get('action') == 'upsert']
+
+                primary_keys_sync_1 = set(primary_keys_list_1)
+                primary_keys_sync_2 = set(primary_keys_list_2)
+
+                if self.is_incremental(stream):
+
+                    bookmark_keys_list_1 = [message.get('data').get(next(iter(expected_bookmark_keys))) for message in synced_records_1.get(stream).get('messages')
+                                            if message.get('action') == 'upsert']
+                    bookmark_keys_list_2 = [message.get('data').get(next(iter(expected_bookmark_keys))) for message in synced_records_2.get(stream).get('messages')
+                                            if message.get('action') == 'upsert']
+
+                    bookmark_key_sync_1 = set(bookmark_keys_list_1)
+                    bookmark_key_sync_2 = set(bookmark_keys_list_2)
+
+                    # Verify bookmark key values are greater than or equal to start date of sync 1
+                    for bookmark_key_value in bookmark_key_sync_1:
+                        self.assertGreaterEqual(self.dt_to_ts(bookmark_key_value), start_date_1_epoch)
+
+                    # Verify bookmark key values are greater than or equal to start date of sync 2
+                    for bookmark_key_value in bookmark_key_sync_2:
+                        self.assertGreaterEqual(self.dt_to_ts(bookmark_key_value), start_date_2_epoch)
+
+                    # Verify the number of records replicated in sync 1 is greater than the number
+                    # of records replicated in sync 2 for stream
+                    self.assertGreater(record_count_sync_1, record_count_sync_2)
+
+                    # Verify the records replicated in sync 2 were also replicated in sync 1
+                    self.assertTrue(primary_keys_sync_2.issubset(primary_keys_sync_1))
+
+                else:
+                    
+                    # Verify that the 2nd sync with a later start date replicates the same number of
+                    # records as the 1st sync.
+                    self.assertEqual(record_count_sync_2, record_count_sync_1)
+
+                    # Verify by primary key the same records are replicated in the 1st and 2nd syncs
+                    self.assertSetEqual(primary_keys_sync_1, primary_keys_sync_2)

--- a/tests/test_gsc_sync_canary.py
+++ b/tests/test_gsc_sync_canary.py
@@ -1,0 +1,24 @@
+from tap_tester import connections
+from base import GoogleSearchConsoleBaseTest
+
+class GoogleSearchConsoleSyncTest(GoogleSearchConsoleBaseTest):
+    """Test tap sync mode and metadata conforms to standards."""
+
+    @staticmethod
+    def name():
+        return "tap_tester_google_search_console_sync_test"
+
+    def test_run(self):
+        """
+        Testing that sync creates the appropriate catalog with valid metadata.
+        Verify that all fields and all streams have selected set to True in the metadata
+        """
+        conn_id = connections.ensure_connection(self)
+
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        self.perform_and_verify_table_and_field_selection(conn_id,found_catalogs)
+
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
+
+        self.assertGreater(sum(record_count_by_stream.values()), 0)


### PR DESCRIPTION
# Description of change
TDL-6750: Get tap-tester tests running and passing
- Moved integration test from tap-tester to tap repository.
- Updated discovery test and added sync canary, start date, and pagination integration test.
- Updated config.yml for run integration test cases.

TDL-13659: Check best practices
- Updated singer-python version from 5.8.1 to 5.12.1.
- Updated environmental variables file name in config.yml. (sandbox -> tap_tester_sandbox)

# Manual QA steps
 - 
 
# Risks
 - No risk
 
# Rollback steps
 - revert this branch
