### PR TITLE
Fixed empty response case of raise_for_error

### DIFF
--- a/tap_google_search_console/client.py
+++ b/tap_google_search_console/client.py
@@ -154,11 +154,7 @@ ERROR_CODE_EXCEPTION_MAPPING = {
 
 def raise_for_error(response):
     # Forming a response message for raising custom exception
-    content_length = len(response.content)
-    if content_length == 0:
-        # There is nothing we can do here since Google has neither sent
-        # us a 2xx response nor a response content.
-        return
+
     try:
         response_json = response.json()
     except Exception:

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -4,11 +4,11 @@ import unittest
 import requests
 
 class Mockresponse:
-    def __init__(self, status_code, json, raise_error, text=None):
+    def __init__(self, status_code, json, raise_error, text=None, content=None):
         self.status_code = status_code
         self.raise_error = raise_error
         self.text = json
-        self.content = "google search console"
+        self.content = content if content is not None else "google search console"
 
     def raise_for_status(self):
         if not self.raise_error:
@@ -19,12 +19,18 @@ class Mockresponse:
     def json(self):
         return self.text
 
-def get_response(status_code, json={}, raise_error=False):
-    return Mockresponse(status_code, json, raise_error)
+def get_response(status_code, json={}, raise_error=False, content=None):
+    return Mockresponse(status_code, json, raise_error, content=content)
 
 @mock.patch("requests.Session.request")
 @mock.patch("tap_google_search_console.client.GoogleClient.get_access_token")
 class TestExceptionHandling(unittest.TestCase):
+
+    def test_error_with_empty_response(self, mocked_access_token, mocked_request):
+        mocked_request.return_value = get_response(400, raise_error = True, content='')
+        google_client = client.GoogleClient("", "", "", "")
+        with self.assertRaises(client.GoogleError):
+            google_client.request("")
 
     def test_400_error(self, mocked_access_token, mocked_request):
         mocked_request.return_value = get_response(400, raise_error = True)
@@ -253,6 +259,12 @@ class TestExceptionHandling(unittest.TestCase):
 
 @mock.patch("requests.Session.post")
 class TestAccessToken(unittest.TestCase):
+
+    def test_error_with_empty_response(self, mocked_request):
+        mocked_request.return_value = get_response(400, raise_error = True, content='')
+        google_client = client.GoogleClient("", "", "", "")
+        with self.assertRaises(client.GoogleError):
+            google_client.get_access_token()
 
     def test_400_error(self, mocked_request):
         mocked_request.return_value = get_response(400, raise_error = True)


### PR DESCRIPTION
# Description of change
- Fix raise_for_error empty response case similar to [tap-github.](https://github.com/singer-io/tap-github/pull/126)

# Manual QA steps
 - Verified that tap is raising an exception for respective error code if a response is empty.
 
# Risks
 - No risk
 
# Rollback steps
 - revert this branch
