### PR TITLE
TDL-16318: Add request timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,13 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-google-search-console/bin/activate
-            python -m unittest discover tests/unittests
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_google_search_console --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - run:
           name: 'Integration Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
     steps:
       - checkout
       - add_ssh_keys
@@ -41,14 +41,7 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-google-search-console \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     --token=$STITCH_API_TOKEN \
-                     tests
+            run-test --tap=tap-google-search-console tests
 workflows:
   version: 2
   commit:

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The [**Google Search Console Setup & Authentication**](https://drive.google.com/
     - [singer-tools](https://github.com/singer-io/singer-tools)
     - [target-stitch](https://github.com/singer-io/target-stitch)
 
-3. Create your tap's `config.json` file. Include the client_id, client_secret, refresh_token, site_urls (website URL properties in a comma delimited list; do not include the domain-level property in the list), start_date (UTC format), and user_agent (tap name with the api user email address).
+3. Create your tap's `config.json` file. Include the client_id, client_secret, refresh_token, site_urls (website URL properties in a comma delimited list; do not include the domain-level property in the list), start_date (UTC format), user_agent (tap name with the api user email address) and request_timeout (the timeout for the requests. Default: 300).
 
     ```json
     {
@@ -141,7 +141,8 @@ The [**Google Search Console Setup & Authentication**](https://drive.google.com/
         "refresh_token": "YOUR_REFRESH_TOKEN",
         "site_urls": "https://example.com, https://www.example.com, http://example.com, http://www.example.com, sc-domain:example.com",
         "start_date": "2019-01-01T00:00:00Z",
-        "user_agent": "tap-google-search-console <api_user_email@example.com>"
+        "user_agent": "tap-google-search-console <api_user_email@example.com>",
+        "request_timeout": 300
     }
     ```
     

--- a/config.json.example
+++ b/config.json.example
@@ -4,5 +4,6 @@
     "refresh_token": "YOUR_REFRESH_TOKEN",
     "site_urls": "https://example.com, https://www.example.com, http://example.com, http://www.example.com, sc-domain:example.com",
     "start_date": "2019-01-01T00:00:00Z",
-    "user_agent": "tap-google-search-console <api_user_email@example.com>"
+    "user_agent": "tap-google-search-console <api_user_email@example.com>",
+    "request_timeout": 300
 }

--- a/tap_google_search_console/__init__.py
+++ b/tap_google_search_console/__init__.py
@@ -37,8 +37,8 @@ def main():
                       parsed_args.config['client_secret'],
                       parsed_args.config['refresh_token'],
                       parsed_args.config['site_urls'],
-                      user_agent=parsed_args.config['user_agent'],
-                      timeout_from_config=parsed_args.config.get('request_timeout')) as client:
+                      parsed_args.config['user_agent'],
+                      parsed_args.config.get('request_timeout')) as client:
 
         state = {}
         if parsed_args.state:

--- a/tap_google_search_console/__init__.py
+++ b/tap_google_search_console/__init__.py
@@ -37,7 +37,8 @@ def main():
                       parsed_args.config['client_secret'],
                       parsed_args.config['refresh_token'],
                       parsed_args.config['site_urls'],
-                      parsed_args.config['user_agent']) as client:
+                      user_agent=parsed_args.config['user_agent'],
+                      timeout_from_config=parsed_args.config.get('request_timeout')) as client:
 
         state = {}
         if parsed_args.state:

--- a/tap_google_search_console/client.py
+++ b/tap_google_search_console/client.py
@@ -183,8 +183,8 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
                  client_secret,
                  refresh_token,
                  site_urls,
-                 timeout_from_config,
-                 user_agent=None):
+                 user_agent=None,
+                 timeout_from_config=None):
         self.__client_id = client_id
         self.__client_secret = client_secret
         self.__refresh_token = refresh_token

--- a/tap_google_search_console/client.py
+++ b/tap_google_search_console/client.py
@@ -273,7 +273,7 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
                           Timeout,
                           max_tries=5,
                           interval=10,
-                          jitter=None)
+                          jitter=None) # Interval value not consistent if jitter not None
     @backoff.on_exception(backoff.expo,
                           (Server5xxError, ConnectionError, GoogleRateLimitExceeded),
                           max_tries=7,

--- a/tap_google_search_console/client.py
+++ b/tap_google_search_console/client.py
@@ -187,7 +187,7 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
                  refresh_token,
                  site_urls,
                  user_agent=None,
-                 timeout_from_config=None):
+                 timeout_from_config=REQUEST_TIMEOUT):
         self.__client_id = client_id
         self.__client_secret = client_secret
         self.__refresh_token = refresh_token

--- a/tap_google_search_console/client.py
+++ b/tap_google_search_console/client.py
@@ -265,14 +265,16 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
         LOGGER.info('Authorized, token expires = {}'.format(self.__expires))
 
     @backoff.on_exception(backoff.constant,
-                          (Timeout),
-                          max_tries=5,
-                          interval=10)
-    @backoff.on_exception(backoff.constant,
                           GoogleQuotaExceededError,
                           max_tries=2,  # Only retry once
                           interval=900,  # Backoff for 15 minutes in case of Quota Exceeded error
                           jitter=None)  # Interval value not consistent if jitter not None
+    # backoff for 5 times, with 10 seconds consistent interval
+    @backoff.on_exception(backoff.constant,
+                          Timeout,
+                          max_tries=5,
+                          interval=10,
+                          jitter=None)
     @backoff.on_exception(backoff.expo,
                           (Server5xxError, ConnectionError, GoogleRateLimitExceeded),
                           max_tries=7,

--- a/tap_google_search_console/client.py
+++ b/tap_google_search_console/client.py
@@ -221,11 +221,7 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
     # during 'Timeout' error there is also possibility of 'ConnectionError',
     # hence added backoff for 'ConnectionError' too.
     @backoff.on_exception(backoff.expo,
-                          Timeout,
-                          max_tries=5,
-                          factor=2)
-    @backoff.on_exception(backoff.expo,
-                          ConnectionError,
+                          (Timeout, ConnectionError),
                           max_tries=5,
                           factor=2)
     def __enter__(self):

--- a/tap_google_search_console/client.py
+++ b/tap_google_search_console/client.py
@@ -200,9 +200,8 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
 
         # if the 'timeout_from_config' value is 0, "0", "" or not passed then set default value of 300 seconds.
         if timeout_from_config and float(timeout_from_config):
-            timeout_value = float(timeout_from_config)
             # update the request timeout for the requests
-            self.request_timeout = timeout_value
+            self.request_timeout = float(timeout_from_config)
         else:
             # set the default timeout of 300 seconds
             self.request_timeout = REQUEST_TIMEOUT

--- a/tap_google_search_console/client.py
+++ b/tap_google_search_console/client.py
@@ -12,6 +12,8 @@ BASE_URL = 'https://www.googleapis.com/webmasters/v3'
 GOOGLE_TOKEN_URI = 'https://oauth2.googleapis.com/token'
 LOGGER = singer.get_logger()
 
+# set default timeout of 300 seconds
+REQUEST_TIMEOUT = 300
 
 class GoogleError(Exception):
     pass
@@ -194,13 +196,15 @@ class GoogleClient: # pylint: disable=too-many-instance-attributes
         self.__expires = None
         self.__session = requests.Session()
         self.base_url = None
-        self.request_timeout = 300 # set the default timeout of 300 seconds
 
-        # if the 'timeout_from_config' value is 0, "0", "" or not passed then do not change default value of 300 seconds.
+        # if the 'timeout_from_config' value is 0, "0", "" or not passed then set default value of 300 seconds.
         if timeout_from_config and float(timeout_from_config):
             timeout_value = float(timeout_from_config)
             # update the request timeout for the requests
             self.request_timeout = timeout_value
+        else:
+            # set the default timeout of 300 seconds
+            self.request_timeout = REQUEST_TIMEOUT
 
     def check_sites_access(self):
         site_list = self.__site_urls.replace(" ", "").split(",")

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -1,0 +1,212 @@
+from unittest import mock
+import tap_google_search_console.client as client
+import unittest
+import requests
+
+class TestTimeoutValue(unittest.TestCase):
+    """
+        Verify the value of timeout is set as expected
+    """
+
+    def test_timeout_value_not_passed_in_config(self):
+        config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "site_urls": "www.test.com",
+            "start_date": "2021-01-01T00:00:00Z",
+            "user_agent": "test_user_agent"
+        }
+
+        # ini
+        #       # initialize 'GoogleClient'tialize 'GoogleClient'
+        cl = client.GoogleClient(config['client_id'],
+                                    config['client_secret'],
+                                    config['refresh_token'],
+                                    config['site_urls'],
+                                    user_agent=config['user_agent'],
+                                    timeout_from_config=config.get('request_timeout'))
+
+        # verify that timeout value is default as request timeout is not passed in config
+        self.assertEquals(300, cl.request_timeout)
+
+    def test_timeout_int_value_passed_in_config(self):
+        config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "site_urls": "www.test.com",
+            "start_date": "2021-01-01T00:00:00Z",
+            "user_agent": "test_user_agent",
+            "request_timeout": 100
+        }
+
+        # initialize 'GoogleClient'
+        cl = client.GoogleClient(config['client_id'],
+                                    config['client_secret'],
+                                    config['refresh_token'],
+                                    config['site_urls'],
+                                    user_agent=config['user_agent'],
+                                    timeout_from_config=config.get('request_timeout'))
+
+        # verify that timeout value is same as the value passed in the config
+        self.assertEquals(100.0, cl.request_timeout)
+
+    def test_timeout_string_value_passed_in_config(self):
+        config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "site_urls": "www.test.com",
+            "start_date": "2021-01-01T00:00:00Z",
+            "user_agent": "test_user_agent",
+            "request_timeout": "100"
+        }
+
+        # initialize 'GoogleClient'
+        cl = client.GoogleClient(config['client_id'],
+                                    config['client_secret'],
+                                    config['refresh_token'],
+                                    config['site_urls'],
+                                    user_agent=config['user_agent'],
+                                    timeout_from_config=config.get('request_timeout'))
+
+        # verify that timeout value is same as the value passed in the config
+        self.assertEquals(100.0, cl.request_timeout)
+
+    def test_timeout_empty_value_passed_in_config(self):
+        config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "site_urls": "www.test.com",
+            "start_date": "2021-01-01T00:00:00Z",
+            "user_agent": "test_user_agent",
+            "request_timeout": ""
+        }
+
+        # initialize 'GoogleClient'
+        cl = client.GoogleClient(config['client_id'],
+                                    config['client_secret'],
+                                    config['refresh_token'],
+                                    config['site_urls'],
+                                    user_agent=config['user_agent'],
+                                    timeout_from_config=config.get('request_timeout'))
+
+        # verify that timeout value is default as request timeout is empty in the config
+        self.assertEquals(300, cl.request_timeout)
+
+    def test_timeout_0_value_passed_in_config(self):
+        config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "site_urls": "www.test.com",
+            "start_date": "2021-01-01T00:00:00Z",
+            "user_agent": "test_user_agent",
+            "request_timeout": 0.0
+        }
+
+        # initialize 'GoogleClient'
+        cl = client.GoogleClient(config['client_id'],
+                                    config['client_secret'],
+                                    config['refresh_token'],
+                                    config['site_urls'],
+                                    user_agent=config['user_agent'],
+                                    timeout_from_config=config.get('request_timeout'))
+
+        # verify that timeout value is default as request timeout is zero in the config
+        self.assertEquals(300, cl.request_timeout)
+
+    def test_timeout_string_0_value_passed_in_config(self):
+        config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "site_urls": "www.test.com",
+            "start_date": "2021-01-01T00:00:00Z",
+            "user_agent": "test_user_agent",
+            "request_timeout": "0.0"
+        }
+
+        # initialize 'GoogleClient'
+        cl = client.GoogleClient(config['client_id'],
+                                    config['client_secret'],
+                                    config['refresh_token'],
+                                    config['site_urls'],
+                                    user_agent=config['user_agent'],
+                                    timeout_from_config=config.get('request_timeout'))
+
+        # verify that timeout value is default as request timeout is zero in the config
+        self.assertEquals(300, cl.request_timeout)
+
+@mock.patch("time.sleep")
+@mock.patch("requests.Session.request")
+class TestTimeoutBackoff(unittest.TestCase):
+    """
+        Verify that we backoff for 5 times for the 'Timeout' error
+    """
+
+    def test_timeout_error__get_access_token(self, mocked_request, mocked_sleep):
+
+        # mock request and raise the 'Timeout' error
+        mocked_request.side_effect = requests.Timeout
+
+        config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "site_urls": "www.test.com",
+            "start_date": "2021-01-01T00:00:00Z",
+            "user_agent": "test_user_agent"
+        }
+
+        # initialize 'GoogleClient'
+        cl = client.GoogleClient(config['client_id'],
+                                    config['client_secret'],
+                                    config['refresh_token'],
+                                    config['site_urls'],
+                                    user_agent=config['user_agent'],
+                                    timeout_from_config=config.get('request_timeout'))
+
+        try:
+            # function call
+            cl.get_access_token()
+        except requests.Timeout:
+            pass
+
+        # verify that we backoff for 5 times
+        self.assertEquals(mocked_request.call_count, 5)
+
+        # initialize 'GoogleClient'
+    @mock.patch("tap_google_search_console.client.GoogleClient.get_access_token")
+    def test_timeout_error__request(self, mocked_get_access_token, mocked_request, mocked_sleep):
+
+        # mock request and raise the 'Timeout' error
+        mocked_request.side_effect = requests.Timeout
+
+        config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "site_urls": "www.test.com",
+            "start_date": "2021-01-01T00:00:00Z",
+            "user_agent": "test_user_agent"
+        }
+
+        # initialize 'GoogleClient'
+        cl = client.GoogleClient(config['client_id'],
+                                    config['client_secret'],
+                                    config['refresh_token'],
+                                    config['site_urls'],
+                                    user_agent=config['user_agent'],
+                                    timeout_from_config=config.get('request_timeout'))
+
+        try:
+            # function call
+            cl.request('GET')
+        except requests.Timeout:
+            pass
+
+        # verify that we backoff for 5 times
+        self.assertEquals(mocked_request.call_count, 5)

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -18,8 +18,7 @@ class TestTimeoutValue(unittest.TestCase):
             "user_agent": "test_user_agent"
         }
 
-        # ini
-        #       # initialize 'GoogleClient'tialize 'GoogleClient'
+        # initialize 'GoogleClient'
         cl = client.GoogleClient(config['client_id'],
                                     config['client_secret'],
                                     config['refresh_token'],
@@ -178,7 +177,6 @@ class TestTimeoutBackoff(unittest.TestCase):
         # verify that we backoff for 5 times
         self.assertEquals(mocked_request.call_count, 5)
 
-        # initialize 'GoogleClient'
     @mock.patch("tap_google_search_console.client.GoogleClient.get_access_token")
     def test_timeout_error__request(self, mocked_get_access_token, mocked_request, mocked_sleep):
 

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -20,11 +20,11 @@ class TestTimeoutValue(unittest.TestCase):
 
         # initialize 'GoogleClient'
         cl = client.GoogleClient(config['client_id'],
-                                    config['client_secret'],
-                                    config['refresh_token'],
-                                    config['site_urls'],
-                                    user_agent=config['user_agent'],
-                                    timeout_from_config=config.get('request_timeout'))
+                                 config['client_secret'],
+                                 config['refresh_token'],
+                                 config['site_urls'],
+                                 user_agent=config['user_agent'],
+                                 timeout_from_config=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is not passed in config
         self.assertEquals(300, cl.request_timeout)
@@ -42,11 +42,11 @@ class TestTimeoutValue(unittest.TestCase):
 
         # initialize 'GoogleClient'
         cl = client.GoogleClient(config['client_id'],
-                                    config['client_secret'],
-                                    config['refresh_token'],
-                                    config['site_urls'],
-                                    user_agent=config['user_agent'],
-                                    timeout_from_config=config.get('request_timeout'))
+                                 config['client_secret'],
+                                 config['refresh_token'],
+                                 config['site_urls'],
+                                 user_agent=config['user_agent'],
+                                 timeout_from_config=config.get('request_timeout'))
 
         # verify that timeout value is same as the value passed in the config
         self.assertEquals(100.0, cl.request_timeout)
@@ -64,11 +64,11 @@ class TestTimeoutValue(unittest.TestCase):
 
         # initialize 'GoogleClient'
         cl = client.GoogleClient(config['client_id'],
-                                    config['client_secret'],
-                                    config['refresh_token'],
-                                    config['site_urls'],
-                                    user_agent=config['user_agent'],
-                                    timeout_from_config=config.get('request_timeout'))
+                                 config['client_secret'],
+                                 config['refresh_token'],
+                                 config['site_urls'],
+                                 user_agent=config['user_agent'],
+                                 timeout_from_config=config.get('request_timeout'))
 
         # verify that timeout value is same as the value passed in the config
         self.assertEquals(100.0, cl.request_timeout)
@@ -86,11 +86,11 @@ class TestTimeoutValue(unittest.TestCase):
 
         # initialize 'GoogleClient'
         cl = client.GoogleClient(config['client_id'],
-                                    config['client_secret'],
-                                    config['refresh_token'],
-                                    config['site_urls'],
-                                    user_agent=config['user_agent'],
-                                    timeout_from_config=config.get('request_timeout'))
+                                 config['client_secret'],
+                                 config['refresh_token'],
+                                 config['site_urls'],
+                                 user_agent=config['user_agent'],
+                                 timeout_from_config=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is empty in the config
         self.assertEquals(300, cl.request_timeout)
@@ -108,11 +108,11 @@ class TestTimeoutValue(unittest.TestCase):
 
         # initialize 'GoogleClient'
         cl = client.GoogleClient(config['client_id'],
-                                    config['client_secret'],
-                                    config['refresh_token'],
-                                    config['site_urls'],
-                                    user_agent=config['user_agent'],
-                                    timeout_from_config=config.get('request_timeout'))
+                                 config['client_secret'],
+                                 config['refresh_token'],
+                                 config['site_urls'],
+                                 user_agent=config['user_agent'],
+                                 timeout_from_config=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is zero in the config
         self.assertEquals(300, cl.request_timeout)
@@ -130,11 +130,11 @@ class TestTimeoutValue(unittest.TestCase):
 
         # initialize 'GoogleClient'
         cl = client.GoogleClient(config['client_id'],
-                                    config['client_secret'],
-                                    config['refresh_token'],
-                                    config['site_urls'],
-                                    user_agent=config['user_agent'],
-                                    timeout_from_config=config.get('request_timeout'))
+                                 config['client_secret'],
+                                 config['refresh_token'],
+                                 config['site_urls'],
+                                 user_agent=config['user_agent'],
+                                 timeout_from_config=config.get('request_timeout'))
 
         # verify that timeout value is default as request timeout is zero in the config
         self.assertEquals(300, cl.request_timeout)
@@ -162,11 +162,11 @@ class TestTimeoutBackoff(unittest.TestCase):
 
         # initialize 'GoogleClient'
         cl = client.GoogleClient(config['client_id'],
-                                    config['client_secret'],
-                                    config['refresh_token'],
-                                    config['site_urls'],
-                                    user_agent=config['user_agent'],
-                                    timeout_from_config=config.get('request_timeout'))
+                                 config['client_secret'],
+                                 config['refresh_token'],
+                                 config['site_urls'],
+                                 user_agent=config['user_agent'],
+                                 timeout_from_config=config.get('request_timeout'))
 
         try:
             # function call
@@ -194,16 +194,54 @@ class TestTimeoutBackoff(unittest.TestCase):
 
         # initialize 'GoogleClient'
         cl = client.GoogleClient(config['client_id'],
-                                    config['client_secret'],
-                                    config['refresh_token'],
-                                    config['site_urls'],
-                                    user_agent=config['user_agent'],
-                                    timeout_from_config=config.get('request_timeout'))
+                                 config['client_secret'],
+                                 config['refresh_token'],
+                                 config['site_urls'],
+                                 user_agent=config['user_agent'],
+                                 timeout_from_config=config.get('request_timeout'))
 
         try:
             # function call
             cl.request('GET')
         except requests.Timeout:
+            pass
+
+        # verify that we backoff for 5 times
+        self.assertEquals(mocked_request.call_count, 5)
+
+@mock.patch("time.sleep")
+@mock.patch("requests.Session.request")
+class TestConnectionErrorBackoff(unittest.TestCase):
+    """
+        Verify that we backoff for 5 times for the 'ConnectionError' error
+    """
+
+    def test_connection_error__get_access_token(self, mocked_request, mocked_sleep):
+
+        # mock request and raise the 'ConnectionError' error
+        mocked_request.side_effect = requests.ConnectionError
+
+        config = {
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "refresh_token": "test_refresh_token",
+            "site_urls": "www.test.com",
+            "start_date": "2021-01-01T00:00:00Z",
+            "user_agent": "test_user_agent"
+        }
+
+        # initialize 'GoogleClient'
+        cl = client.GoogleClient(config['client_id'],
+                                 config['client_secret'],
+                                 config['refresh_token'],
+                                 config['site_urls'],
+                                 user_agent=config['user_agent'],
+                                 timeout_from_config=config.get('request_timeout'))
+
+        try:
+            # function call
+            cl.get_access_token()
+        except requests.ConnectionError:
             pass
 
         # verify that we backoff for 5 times

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -161,24 +161,22 @@ class TestTimeoutBackoff(unittest.TestCase):
         }
 
         # initialize 'GoogleClient'
-        cl = client.GoogleClient(config['client_id'],
-                                 config['client_secret'],
-                                 config['refresh_token'],
-                                 config['site_urls'],
-                                 user_agent=config['user_agent'],
-                                 timeout_from_config=config.get('request_timeout'))
-
         try:
-            # function call
-            cl.get_access_token()
+            with client.GoogleClient(config['client_id'],
+                                     config['client_secret'],
+                                     config['refresh_token'],
+                                     config['site_urls'],
+                                     user_agent=config['user_agent'],
+                                     timeout_from_config=config.get('request_timeout')) as cl:
+                pass
+
         except requests.Timeout:
             pass
 
         # verify that we backoff for 5 times
         self.assertEquals(mocked_request.call_count, 5)
 
-    @mock.patch("tap_google_search_console.client.GoogleClient.get_access_token")
-    def test_timeout_error__request(self, mocked_get_access_token, mocked_request, mocked_sleep):
+    def test_timeout_error__request(self, mocked_request, mocked_sleep):
 
         # mock request and raise the 'Timeout' error
         mocked_request.side_effect = requests.Timeout
@@ -231,16 +229,14 @@ class TestConnectionErrorBackoff(unittest.TestCase):
         }
 
         # initialize 'GoogleClient'
-        cl = client.GoogleClient(config['client_id'],
-                                 config['client_secret'],
-                                 config['refresh_token'],
-                                 config['site_urls'],
-                                 user_agent=config['user_agent'],
-                                 timeout_from_config=config.get('request_timeout'))
-
         try:
-            # function call
-            cl.get_access_token()
+            with client.GoogleClient(config['client_id'],
+                                     config['client_secret'],
+                                     config['refresh_token'],
+                                     config['site_urls'],
+                                     user_agent=config['user_agent'],
+                                     timeout_from_config=config.get('request_timeout')) as cl:
+                pass
         except requests.ConnectionError:
             pass
 


### PR DESCRIPTION
# Description of change
TDL-16318: Add request timeout
- Use default timeout of 300 seconds if the user does not enter the preferred timeout value

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
