### PR TITLE
TDL-19978 add missing integration tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -102,7 +102,7 @@ class GoogleSearchConsoleBaseTest(unittest.TestCase):
             "performance_report_page": {
                 self.PRIMARY_KEYS: {"site_url", "search_type", "date", "page"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"page", "date"}
+                self.REPLICATION_KEYS: {"date"}
             },
             "performance_report_query": {
                 self.PRIMARY_KEYS: {"site_url", "search_type", "date", "query"},
@@ -114,6 +114,10 @@ class GoogleSearchConsoleBaseTest(unittest.TestCase):
     def expected_streams(self):
         """A set of expected stream names"""
         return set(self.expected_metadata().keys())
+
+    @staticmethod
+    def exclude_streams():
+        return {'performance_report_custom'}
 
     def expected_primary_keys(self):
         """return a dictionary with key of table name and value as a set of primary key fields"""

--- a/tests/base.py
+++ b/tests/base.py
@@ -102,7 +102,7 @@ class GoogleSearchConsoleBaseTest(unittest.TestCase):
             "performance_report_page": {
                 self.PRIMARY_KEYS: {"site_url", "search_type", "date", "page"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"date"}
+                self.REPLICATION_KEYS: {"page", "date"}
             },
             "performance_report_query": {
                 self.PRIMARY_KEYS: {"site_url", "search_type", "date", "query"},

--- a/tests/base.py
+++ b/tests/base.py
@@ -4,8 +4,7 @@ from datetime import timedelta
 from datetime import datetime as dt
 import time
 
-import singer
-from tap_tester import connections, menagerie, runner
+from tap_tester import connections, menagerie, runner, LOGGER
 
 class GoogleSearchConsoleBaseTest(unittest.TestCase):
     """
@@ -21,11 +20,11 @@ class GoogleSearchConsoleBaseTest(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     FULL_TABLE = "FULL_TABLE"
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
-    DATETIME_FMT = {
+    DATETIME_FMT = [
         "%Y-%m-%dT%H:%M:%SZ",
         "%Y-%m-%dT%H:%M:%S.000000Z"
-    }
-    start_date = ""
+    ]
+    start_date = dt.utcnow()-timedelta(days=14)
     properties = {
         "client_id": "TAP_GOOGLE_SEARCH_CONSOLE_CLIENT_ID",
 	"site_urls": "TAP_GOOGLE_SEARCH_CONSOLE_SITE_URLS"
@@ -47,8 +46,9 @@ class GoogleSearchConsoleBaseTest(unittest.TestCase):
 
     def get_properties(self, original: bool = True):
         """Configuration properties required for the tap."""
+
         properties_dict = {
-            'start_date': dt.strftime(dt.utcnow()-timedelta(days=14), self.START_DATE_FORMAT),
+            'start_date': self.start_date if isinstance(self.start_date, str) else dt.strftime(self.start_date, self.START_DATE_FORMAT),
         }
         props = self.properties
         for prop in props:
@@ -57,7 +57,6 @@ class GoogleSearchConsoleBaseTest(unittest.TestCase):
         if original:
             return properties_dict
 
-        properties_dict["start_date"] = self.start_date
         return properties_dict
 
     def get_credentials(self):
@@ -103,7 +102,7 @@ class GoogleSearchConsoleBaseTest(unittest.TestCase):
             "performance_report_page": {
                 self.PRIMARY_KEYS: {"site_url", "search_type", "date", "page"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"date", "page"}
+                self.REPLICATION_KEYS: {"page", "date"}
             },
             "performance_report_query": {
                 self.PRIMARY_KEYS: {"site_url", "search_type", "date", "query"},
@@ -177,9 +176,8 @@ class GoogleSearchConsoleBaseTest(unittest.TestCase):
         self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
 
         found_catalog_names = set(map(lambda c: c['stream_name'], found_catalogs))
-        print(found_catalog_names)
         self.assertSetEqual(self.expected_streams(), found_catalog_names, msg="discovered schemas do not match")
-        print("discovered schemas are OK")
+        LOGGER.info("discovered schemas are OK")
 
         return found_catalogs
 
@@ -203,7 +201,7 @@ class GoogleSearchConsoleBaseTest(unittest.TestCase):
             sum(sync_record_count.values()), 0,
             msg="failed to replicate any data: {}".format(sync_record_count)
         )
-        print("total replicated row count: {}".format(sum(sync_record_count.values())))
+        LOGGER.info("total replicated row count: %s", sum(sync_record_count.values()))
 
         return sync_record_count
 
@@ -232,7 +230,7 @@ class GoogleSearchConsoleBaseTest(unittest.TestCase):
 
             # Verify all testable streams are selected
             selected = catalog_entry.get('annotated-schema').get('selected')
-            print("Validating selection on {}: {}".format(cat['stream_name'], selected))
+            LOGGER.info("Validating selection on %s: %s", cat['stream_name'], selected)
             if cat['stream_name'] not in expected_selected:
                 self.assertFalse(selected, msg="Stream selected, but not testable.")
                 continue # Skip remaining assertions if we aren't selecting this stream
@@ -242,8 +240,7 @@ class GoogleSearchConsoleBaseTest(unittest.TestCase):
                 # Verify all fields within each selected stream are selected
                 for field, field_props in catalog_entry.get('annotated-schema').get('properties').items():
                     field_selected = field_props.get('selected')
-                    print("\tValidating selection on {}.{}: {}".format(
-                        cat['stream_name'], field, field_selected))
+                    LOGGER.info("\tValidating selection on %s.%s: %s", cat['stream_name'], field, field_selected)
                     self.assertTrue(field_selected, msg="Field not selected.")
             else:
                 # Verify only automatic fields are selected

--- a/tests/base.py
+++ b/tests/base.py
@@ -20,10 +20,10 @@ class GoogleSearchConsoleBaseTest(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     FULL_TABLE = "FULL_TABLE"
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
-    DATETIME_FMT = [
+    DATETIME_FMT = {
         "%Y-%m-%dT%H:%M:%SZ",
         "%Y-%m-%dT%H:%M:%S.000000Z"
-    ]
+    }
     start_date = dt.utcnow()-timedelta(days=14)
     properties = {
         "client_id": "TAP_GOOGLE_SEARCH_CONSOLE_CLIENT_ID",

--- a/tests/test_gsc_all_fields.py
+++ b/tests/test_gsc_all_fields.py
@@ -1,5 +1,3 @@
-import os
-
 from tap_tester import runner, connections, menagerie
 
 from base import GoogleSearchConsoleBaseTest
@@ -19,26 +17,24 @@ class TestGoogleSearchConsoleAllFields(GoogleSearchConsoleBaseTest):
         - Verify no unexpected streams were replicated
         - Verify that more than just the automatic fields are replicated for each stream.
         """
+        # Excluding the custom report stream to decrease the CCI job duration
+        # Currently custom report stream takes more than an hour to sync data for past 14 days
+        exclude_streams = {'performance_report_custom'}
+        expected_streams = self.expected_streams() - exclude_streams
 
-        excluded_streams = {}
-
-        expected_streams = self.expected_streams() - excluded_streams
-
-        # instantiate connection
+        # Instantiate connection
         conn_id = connections.ensure_connection(self)
 
-        # run check mode
+        # Run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
-        # table and field selection
+        # Table and field selection
         test_catalogs_all_fields = [catalog for catalog in found_catalogs
                                     if catalog.get('stream_name') in expected_streams]
-        self.perform_and_verify_table_and_field_selection(
-            conn_id, test_catalogs_all_fields, select_all_fields=True,
-        )
+        self.perform_and_verify_table_and_field_selection(conn_id, test_catalogs_all_fields, select_all_fields=True)
 
-        # grab metadata after performing table-and-field selection to set expectations
-        stream_to_all_catalog_fields = dict() # used for asserting all fields are replicated
+        # Grab metadata after performing table-and-field selection to set expectations
+        stream_to_all_catalog_fields = dict() # Used for asserting all fields are replicated
         for catalog in test_catalogs_all_fields:
             stream_id, stream_name = catalog['stream_id'], catalog['stream_name']
             catalog_entry = menagerie.get_annotated_schema(conn_id, stream_id)
@@ -47,7 +43,7 @@ class TestGoogleSearchConsoleAllFields(GoogleSearchConsoleBaseTest):
                                           if md_entry['breadcrumb'] != []]
             stream_to_all_catalog_fields[stream_name] = set(fields_from_field_level_md)
 
-        # run initial sync
+        # Run initial sync
         record_count_by_stream = self.run_and_verify_sync(conn_id)
         synced_records = runner.get_records_from_target_output()
 
@@ -57,13 +53,13 @@ class TestGoogleSearchConsoleAllFields(GoogleSearchConsoleBaseTest):
 
         for stream in expected_streams:
             with self.subTest(stream=stream):
-                # expected values
+                # Expected values
                 expected_automatic_keys = self.expected_primary_keys().get(stream)
 
-                # get all expected keys
+                # Get all expected keys
                 expected_all_keys = stream_to_all_catalog_fields[stream]
 
-                # collect actual values
+                # Collect actual values
                 messages = synced_records.get(stream)
                 actual_all_keys = [set(message['data'].keys()) for message in messages['messages']
                                    if message['action'] == 'upsert'][0]
@@ -71,8 +67,7 @@ class TestGoogleSearchConsoleAllFields(GoogleSearchConsoleBaseTest):
                 # Verify that you get some records for each stream
                 self.assertGreater(record_count_by_stream.get(stream, -1), 0)
 
-                # verify all fields for a stream were replicated
+                # Verify all fields for a stream were replicated
                 self.assertGreater(len(expected_all_keys), len(expected_automatic_keys))
                 self.assertTrue(expected_automatic_keys.issubset(expected_all_keys), msg=f'{expected_automatic_keys-expected_all_keys} is not in "expected_all_keys"')
                 self.assertSetEqual(expected_all_keys, actual_all_keys)
-            

--- a/tests/test_gsc_all_fields.py
+++ b/tests/test_gsc_all_fields.py
@@ -19,8 +19,7 @@ class TestGoogleSearchConsoleAllFields(GoogleSearchConsoleBaseTest):
         """
         # Excluding the custom report stream to decrease the CCI job duration
         # Currently custom report stream takes more than an hour to sync data for past 14 days
-        exclude_streams = {'performance_report_custom'}
-        expected_streams = self.expected_streams() - exclude_streams
+        expected_streams = self.expected_streams() - self.exclude_streams()
 
         # Instantiate connection
         conn_id = connections.ensure_connection(self)

--- a/tests/test_gsc_all_fields.py
+++ b/tests/test_gsc_all_fields.py
@@ -1,0 +1,78 @@
+import os
+
+from tap_tester import runner, connections, menagerie
+
+from base import GoogleSearchConsoleBaseTest
+
+
+class TestGoogleSearchConsoleAllFields(GoogleSearchConsoleBaseTest):
+    """Test that with all fields selected for a stream automatic and available fields are replicated"""
+
+    @staticmethod
+    def name():
+        return "tap_tester_google_search_console_all_fields_test"
+
+    def test_run(self):
+        """
+        Ensure running the tap with all streams and fields selected results in the
+        replication of all fields.
+        - Verify no unexpected streams were replicated
+        - Verify that more than just the automatic fields are replicated for each stream.
+        """
+
+        excluded_streams = {}
+
+        expected_streams = self.expected_streams() - excluded_streams
+
+        # instantiate connection
+        conn_id = connections.ensure_connection(self)
+
+        # run check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # table and field selection
+        test_catalogs_all_fields = [catalog for catalog in found_catalogs
+                                    if catalog.get('stream_name') in expected_streams]
+        self.perform_and_verify_table_and_field_selection(
+            conn_id, test_catalogs_all_fields, select_all_fields=True,
+        )
+
+        # grab metadata after performing table-and-field selection to set expectations
+        stream_to_all_catalog_fields = dict() # used for asserting all fields are replicated
+        for catalog in test_catalogs_all_fields:
+            stream_id, stream_name = catalog['stream_id'], catalog['stream_name']
+            catalog_entry = menagerie.get_annotated_schema(conn_id, stream_id)
+            fields_from_field_level_md = [md_entry['breadcrumb'][1]
+                                          for md_entry in catalog_entry['metadata']
+                                          if md_entry['breadcrumb'] != []]
+            stream_to_all_catalog_fields[stream_name] = set(fields_from_field_level_md)
+
+        # run initial sync
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
+        synced_records = runner.get_records_from_target_output()
+
+        # Verify no unexpected streams were replicated
+        synced_stream_names = set(synced_records.keys())
+        self.assertSetEqual(expected_streams, synced_stream_names)
+
+        for stream in expected_streams:
+            with self.subTest(stream=stream):
+                # expected values
+                expected_automatic_keys = self.expected_primary_keys().get(stream)
+
+                # get all expected keys
+                expected_all_keys = stream_to_all_catalog_fields[stream]
+
+                # collect actual values
+                messages = synced_records.get(stream)
+                actual_all_keys = [set(message['data'].keys()) for message in messages['messages']
+                                   if message['action'] == 'upsert'][0]
+
+                # Verify that you get some records for each stream
+                self.assertGreater(record_count_by_stream.get(stream, -1), 0)
+
+                # verify all fields for a stream were replicated
+                self.assertGreater(len(expected_all_keys), len(expected_automatic_keys))
+                self.assertTrue(expected_automatic_keys.issubset(expected_all_keys), msg=f'{expected_automatic_keys-expected_all_keys} is not in "expected_all_keys"')
+                self.assertSetEqual(expected_all_keys, actual_all_keys)
+            

--- a/tests/test_gsc_automatic_fields.py
+++ b/tests/test_gsc_automatic_fields.py
@@ -4,8 +4,8 @@ from tap_tester import runner, connections
 class GoogleConsoleAutomaticFields(GoogleSearchConsoleBaseTest):
     
     @staticmethod
-    def name(self):
-        return "tap_tester_google_console_search_automatic_fields_test"
+    def name():
+        return "tap_tester_google_console_search_automatic_fields"
     
     def test_run(self):
         """
@@ -18,15 +18,15 @@ class GoogleConsoleAutomaticFields(GoogleSearchConsoleBaseTest):
         that 251 (or more) records have been posted for that stream.
         """
 
-        expected_streams = self.streams_to_test()
+        expected_streams = self.expected_streams()
 
-        # instantiate connection
+        # Instantiate connection
         conn_id = connections.ensure_connection(self)
 
-        # run check mode
+        # Run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
-        # table and field selection
+        # Table and Field selection
         test_catalogs_automatic_fields = [catalog for catalog in found_catalogs
                                           if catalog.get('stream_name') in expected_streams]
 
@@ -34,17 +34,17 @@ class GoogleConsoleAutomaticFields(GoogleSearchConsoleBaseTest):
             conn_id, test_catalogs_automatic_fields, select_all_fields=False,
         )
 
-        # run initial sync
+        # Run initial sync
         record_count_by_stream = self.run_and_verify_sync(conn_id)
         synced_records = runner.get_records_from_target_output()
 
         for stream in expected_streams:
             with self.subTest(stream=stream):
 
-                # expected values
+                # Expected values
                 expected_keys = self.expected_automatic_fields().get(stream)
 
-                # collect actual values
+                # Collect actual values
                 data = synced_records.get(stream)
                 record_messages_keys = [set(row['data'].keys()) for row in data['messages']]
                 primary_keys_list = [tuple(message.get('data').get(expected_pk) for expected_pk in expected_keys)
@@ -63,6 +63,6 @@ class GoogleConsoleAutomaticFields(GoogleSearchConsoleBaseTest):
                     self.assertSetEqual(expected_keys, actual_keys)
                     
                 # Verify if all the replicated records have unique primary key values
-                self.assertEqaul(len(unique_primary_keys_list), len(primary_keys_list),
+                self.assertEqual(len(unique_primary_keys_list), len(primary_keys_list),
                                  msg="Replicated record does not have unique primary key values.")
         

--- a/tests/test_gsc_automatic_fields.py
+++ b/tests/test_gsc_automatic_fields.py
@@ -1,0 +1,68 @@
+from base import GoogleSearchConsoleBaseTest
+from tap_tester import runner, connections
+
+class GoogleConsoleAutomaticFields(GoogleSearchConsoleBaseTest):
+    
+    @staticmethod
+    def name(self):
+        return "tap_tester_google_console_search_automatic_fields_test"
+    
+    def test_run(self):
+        """
+        Verify that for each stream you can get multiple pages of data
+        when no fields are selected and only the automatic fields are replicated.
+
+        PREREQUISITE
+        For EACH stream add enough data that you surpass the limit of a single
+        fetch of data.  For instance if you have a limit of 250 records ensure
+        that 251 (or more) records have been posted for that stream.
+        """
+
+        expected_streams = self.streams_to_test()
+
+        # instantiate connection
+        conn_id = connections.ensure_connection(self)
+
+        # run check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # table and field selection
+        test_catalogs_automatic_fields = [catalog for catalog in found_catalogs
+                                          if catalog.get('stream_name') in expected_streams]
+
+        self.perform_and_verify_table_and_field_selection(
+            conn_id, test_catalogs_automatic_fields, select_all_fields=False,
+        )
+
+        # run initial sync
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
+        synced_records = runner.get_records_from_target_output()
+
+        for stream in expected_streams:
+            with self.subTest(stream=stream):
+
+                # expected values
+                expected_keys = self.expected_automatic_fields().get(stream)
+
+                # collect actual values
+                data = synced_records.get(stream)
+                record_messages_keys = [set(row['data'].keys()) for row in data['messages']]
+                primary_keys_list = [tuple(message.get('data').get(expected_pk) for expected_pk in expected_keys)
+                    for message in data.get('messages')
+                    if message.get('action') == 'upsert']
+                unique_primary_keys_list = set(primary_keys_list)
+
+
+                # Verify that you get some records for each stream
+                self.assertGreater(
+                    record_count_by_stream.get(stream, -1), 0,
+                    msg="The number of records is not over the stream max limit")
+
+                # Verify that only the automatic fields are sent to the target
+                for actual_keys in record_messages_keys:
+                    self.assertSetEqual(expected_keys, actual_keys)
+                    
+                # Verify if all the replicated records have unique primary key values
+                self.assertEqaul(len(unique_primary_keys_list), len(primary_keys_list),
+                                 msg="Replicated record does not have unique primary key values.")
+        

--- a/tests/test_gsc_automatic_fields.py
+++ b/tests/test_gsc_automatic_fields.py
@@ -1,7 +1,12 @@
 from base import GoogleSearchConsoleBaseTest
 from tap_tester import runner, connections
 
+
 class GoogleConsoleAutomaticFields(GoogleSearchConsoleBaseTest):
+    """
+    Verify that for each stream you can get multiple pages of data
+    when no fields are selected and only the automatic fields are replicated.
+    """
     
     @staticmethod
     def name():
@@ -9,13 +14,9 @@ class GoogleConsoleAutomaticFields(GoogleSearchConsoleBaseTest):
     
     def test_run(self):
         """
-        Verify that for each stream you can get multiple pages of data
-        when no fields are selected and only the automatic fields are replicated.
-
-        PREREQUISITE
-        For EACH stream add enough data that you surpass the limit of a single
-        fetch of data.  For instance if you have a limit of 250 records ensure
-        that 251 (or more) records have been posted for that stream.
+        • Verify we can deselect all fields except when inclusion=automatic, which is handled by base.py methods
+        • Verify that only the automatic fields are sent to the target.
+        • Verify that all replicated records have unique primary key values.
         """
 
         expected_streams = self.expected_streams()

--- a/tests/test_gsc_bookmarks.py
+++ b/tests/test_gsc_bookmarks.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from datetime import datetime as dt
+import site
 from tap_tester import connections, menagerie, runner
 from base import GoogleSearchConsoleBaseTest
 from tap_tester.logger import LOGGER
@@ -7,12 +8,12 @@ from tap_tester.logger import LOGGER
 class GoogleSearchConsoleBookMarkTest(GoogleSearchConsoleBaseTest):
     """Test tap sets a bookmark and respects it for the next sync of a stream"""
 
-    def name(self):
-        return "tap_tester_google_search_console_bookmark_test"
-    
     @staticmethod
+    def name():
+        return "tap_tester_google_search_console_bookmark_test"
+
     def get_second_sync_bookmark_date(self):
-        return dt.strftime(dt.utcnow()-timedelta(days=7), self.START_DATE_FORMAT)
+        return dt.strftime(dt.utcnow()-timedelta(days=7), "%Y-%m-%dT00:00:00.000000Z")
 
     def test_run(self):
         """
@@ -29,11 +30,14 @@ class GoogleSearchConsoleBookMarkTest(GoogleSearchConsoleBaseTest):
         For EACH stream that is incrementally replicated there are multiple rows of data with
             different values for the replication key
         """
-        
-        
-        expected_streams = self.expected_streams()
+
+        # Excluding the custom report stream to decrease the CCI job duration
+        # Currently custom report stream takes more than an hour to sync data for past 14 days
+        exclude_streams = {'performance_report_custom'}
+        expected_streams = self.expected_streams() - exclude_streams
         expected_replication_keys = self.expected_replication_keys()
         expected_replication_methods = self.expected_replication_method()
+        site_url = self.get_properties().get('site_urls', []).split(',')[0]
 
         ##########################################################################
         # First Sync
@@ -57,16 +61,16 @@ class GoogleSearchConsoleBookMarkTest(GoogleSearchConsoleBaseTest):
         ##########################################################################
         # Update State Between Syncs
         ##########################################################################
-        
+
         LOGGER.info("Current Bookmark: {}".format(first_sync_bookmarks))
         second_sync_bookmark_date = self.get_second_sync_bookmark_date()
         new_states = {'currently_syncing': None,
-                      "bookmarks": {"performance_report_device": {"https://www.stitchdata.com/": {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}},
-                                     "performance_report_page": {"https://www.stitchdata.com/": {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}}, 
-                                     "performance_report_country": {"https://www.stitchdata.com/": {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}},
-                                     "performance_report_query": {"https://www.stitchdata.com/": {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}},
-                                     "performance_report_date": {"https://www.stitchdata.com/": {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}},
-                                     "performance_report_custom": {"https://www.stitchdata.com/": {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}}}}
+                      "bookmarks": {"performance_report_device": {site_url: {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}},
+                                     "performance_report_page": {site_url: {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}},
+                                     "performance_report_country": {site_url: {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}},
+                                     "performance_report_query": {site_url: {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}},
+                                     "performance_report_date": {site_url: {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}},
+                                     "performance_report_custom": {site_url: {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}}}}
 
         menagerie.set_state(conn_id, new_states)
         LOGGER.info("New Bookmark: {}".format(menagerie.get_state(conn_id)))
@@ -80,26 +84,16 @@ class GoogleSearchConsoleBookMarkTest(GoogleSearchConsoleBaseTest):
         second_sync_bookmarks = menagerie.get_state(conn_id)
 
         ##########################################################################
-        # Third Sync: 
-        #   To test that we get at least one record per replication
-        #   Assuming that there no are new records between 2nd and 3rd sync there should only one record,
-        #   otherwise we should get more than 1 records
-        ##########################################################################
-
-        third_sync_record_count = self.run_and_verify_sync(conn_id)
-        third_sync_bookmarks = menagerie.get_state(conn_id)
-
-        ##########################################################################
         # Test By Stream
         ##########################################################################
 
         for stream in expected_streams:
             with self.subTest(stream=stream):
 
-                # expected values
+                # Expected values
                 expected_replication_method = expected_replication_methods[stream]
 
-                # collect information for assertions from syncs 1 & 2 base on expected values
+                # Collect information for assertions from syncs 1 & 2 base on expected values
                 first_sync_count = first_sync_record_count.get(stream, 0)
                 second_sync_count = second_sync_record_count.get(stream, 0)
                 first_sync_messages = [record.get('data') for record in
@@ -115,17 +109,16 @@ class GoogleSearchConsoleBookMarkTest(GoogleSearchConsoleBaseTest):
                 first_bookmark_value = first_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
                 second_bookmark_value = second_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
 
-                # collect information for assertions from syncs 1 & 2 base on expected values
-                third_sync_count = third_sync_record_count.get(stream, 0)
-                third_bookmark_value = third_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
-
                 if expected_replication_method == self.INCREMENTAL:
 
-                    # collect information specific to incremental streams from syncs 1 & 2
+                    # Collect information specific to incremental streams from syncs 1 & 2
                     replication_key = next(iter(expected_replication_keys[stream]))
-                    
+
+                    if stream == 'performance_report_page':
+                        replication_key = 'date'
+
                     simulated_bookmark_value = new_states['bookmarks'][stream]
-                    
+
                     # Verify the first sync sets a bookmark of the expected form
                     self.assertIsNotNone(first_bookmark_value)
 
@@ -135,36 +128,38 @@ class GoogleSearchConsoleBookMarkTest(GoogleSearchConsoleBaseTest):
                     # Verify second sync record count is less than or equal to first sync record
                     self.assertLessEqual(second_sync_count, first_sync_count)
 
-                    # Verify the second sync bookmark is Greater or Equal to the first sync bookmark
-                    self.assertGreaterEqual(second_bookmark_value.get(replication_key), first_bookmark_value.get(replication_key))
-
+                    # Verify the second sync bookmark is Greater or Equal to the first sync bookmark for search types
+                    self.assertGreaterEqual(second_bookmark_value.get(site_url).get('web'), first_bookmark_value.get(site_url).get('web'))
+                    self.assertGreaterEqual(second_bookmark_value.get(site_url).get('image'), first_bookmark_value.get(site_url).get('image'))
+                    self.assertGreaterEqual(second_bookmark_value.get(site_url).get('video'), first_bookmark_value.get(site_url).get('video'))
                     for record in first_sync_messages:
-
+                        search_type = record.get('search_type', 'web')
                         # Verify the first sync bookmark value is the max replication key value for a given stream
                         replication_key_value = record.get(replication_key)
-   
-                        self.assertLessEqual(replication_key_value,
-                                            first_bookmark_value[replication_key],
+                        self.assertLessEqual(replication_key_value, first_bookmark_value.get(site_url).get(search_type),
                                             msg="First sync bookmark was set incorrectly, a record with a greater replication-key value was synced.")
-                    
+
                     for record in second_sync_messages:
                         # Verify the second sync replication key value is Greater or Equal to the first sync bookmark
                         replication_key_value = record.get(replication_key)
-
-                        self.assertLessEqual(simulated_bookmark_value[replication_key],
+                        search_type = record.get('search_type', 'web')
+                        self.assertLessEqual(simulated_bookmark_value.get(site_url).get(search_type),
                                             replication_key_value,
                                             msg="Second sync bookmark was set incorrectly, a record with a greater replication-key value was synced.")
 
                         # Verify the second sync bookmark value is the max replication key value for a given stream
                         self.assertLessEqual(replication_key_value,
-                                            second_bookmark_value[replication_key],
+                                            second_bookmark_value.get(site_url).get(search_type),
                                             msg="Second sync bookmark was set incorrectly, a record with a greater replication-key value was synced.")
-                        
-                # Verify at least 1 record was replicated in the second sync
-                self.assertGreater(second_sync_count, 0, msg="We are not fully testing bookmarking for {}".format(stream))
 
-                # Verify at least 1 record was replicated in the third sync
-                if second_bookmark_value[replication_key] == third_bookmark_value[replication_key]:
-                    self.assertEquals(third_sync_count, 1, msg="We are not fully testing bookmarking for {}".format(stream))
+                    # Verify at least 3 record was replicated in the second sync.
+                    # Asserting with 3 since each stream would have data for image, web, video search types
+                    self.assertGreaterEqual(second_sync_count, 3, msg="We are not fully testing bookmarking for {}".format(stream))
+
                 else:
-                    self.assertGreater(third_sync_count, 1, msg="We are not fully testing bookmarking for {}".format(stream))
+                    # Verify bookmark values are none for Full Table streams
+                    self.assertIsNone(first_bookmark_value)
+                    self.assertIsNone(second_bookmark_value)
+
+                    # Verify record count is same in first and second sync for Full Table streams
+                    self.assertEqual(first_sync_record_count[stream], second_sync_record_count[stream])

--- a/tests/test_gsc_bookmarks.py
+++ b/tests/test_gsc_bookmarks.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 from datetime import datetime as dt
-import site
 from tap_tester import connections, menagerie, runner
 from base import GoogleSearchConsoleBaseTest
 from tap_tester.logger import LOGGER
@@ -33,8 +32,7 @@ class GoogleSearchConsoleBookMarkTest(GoogleSearchConsoleBaseTest):
 
         # Excluding the custom report stream to decrease the CCI job duration
         # Currently custom report stream takes more than an hour to sync data for past 14 days
-        exclude_streams = {'performance_report_custom'}
-        expected_streams = self.expected_streams() - exclude_streams
+        expected_streams = self.expected_streams() - self.exclude_streams()
         expected_replication_keys = self.expected_replication_keys()
         expected_replication_methods = self.expected_replication_method()
         site_url = self.get_properties().get('site_urls', []).split(',')[0]
@@ -47,7 +45,7 @@ class GoogleSearchConsoleBookMarkTest(GoogleSearchConsoleBaseTest):
         # Run in check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
-        # table and field selection
+        # Table and field selection
         catalog_entries = [catalog for catalog in found_catalogs
                            if catalog.get('tap_stream_id') in expected_streams]
 
@@ -113,9 +111,6 @@ class GoogleSearchConsoleBookMarkTest(GoogleSearchConsoleBaseTest):
 
                     # Collect information specific to incremental streams from syncs 1 & 2
                     replication_key = next(iter(expected_replication_keys[stream]))
-
-                    if stream == 'performance_report_page':
-                        replication_key = 'date'
 
                     simulated_bookmark_value = new_states['bookmarks'][stream]
 

--- a/tests/test_gsc_bookmarks.py
+++ b/tests/test_gsc_bookmarks.py
@@ -110,7 +110,9 @@ class GoogleSearchConsoleBookMarkTest(GoogleSearchConsoleBaseTest):
                 if expected_replication_method == self.INCREMENTAL:
 
                     # Collect information specific to incremental streams from syncs 1 & 2
-                    replication_key = next(iter(expected_replication_keys[stream]))
+                    # Set date as replication key for performance_report_page since only date is being used for filtering
+                    replication_key = next(iter(expected_replication_keys[stream])) \
+                        if stream != 'performance_report_page' else 'date'
 
                     simulated_bookmark_value = new_states['bookmarks'][stream]
 

--- a/tests/test_gsc_bookmarks.py
+++ b/tests/test_gsc_bookmarks.py
@@ -1,0 +1,170 @@
+from datetime import timedelta
+from datetime import datetime as dt
+from tap_tester import connections, menagerie, runner
+from base import GoogleSearchConsoleBaseTest
+from tap_tester.logger import LOGGER
+
+class GoogleSearchConsoleBookMarkTest(GoogleSearchConsoleBaseTest):
+    """Test tap sets a bookmark and respects it for the next sync of a stream"""
+
+    def name(self):
+        return "tap_tester_google_search_console_bookmark_test"
+    
+    @staticmethod
+    def get_second_sync_bookmark_date(self):
+        return dt.strftime(dt.utcnow()-timedelta(days=7), self.START_DATE_FORMAT)
+
+    def test_run(self):
+        """
+        Verify that for each stream you can do a sync which records bookmarks.
+        That the bookmark is the maximum value sent to the target for the replication key.
+        That a second sync respects the bookmark
+            All data of the second sync is >= the bookmark from the first sync
+            The number of records in the 2nd sync is less then the first (This assumes that
+                new data added to the stream is done at a rate slow enough that you haven't
+                doubled the amount of data from the start date to the first sync between
+                the first sync and second sync run in this test)
+        Verify that for full table stream, all data replicated in sync 1 is replicated again in sync 2.
+        PREREQUISITE
+        For EACH stream that is incrementally replicated there are multiple rows of data with
+            different values for the replication key
+        """
+        
+        
+        expected_streams = self.expected_streams()
+        expected_replication_keys = self.expected_replication_keys()
+        expected_replication_methods = self.expected_replication_method()
+
+        ##########################################################################
+        # First Sync
+        ##########################################################################
+        conn_id = connections.ensure_connection(self)
+
+        # Run in check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # table and field selection
+        catalog_entries = [catalog for catalog in found_catalogs
+                           if catalog.get('tap_stream_id') in expected_streams]
+
+        self.perform_and_verify_table_and_field_selection(conn_id, catalog_entries)
+
+        # Run a first sync job using orchestrator
+        first_sync_record_count = self.run_and_verify_sync(conn_id)
+        first_sync_records = runner.get_records_from_target_output()
+        first_sync_bookmarks = menagerie.get_state(conn_id)
+
+        ##########################################################################
+        # Update State Between Syncs
+        ##########################################################################
+        
+        LOGGER.info("Current Bookmark: {}".format(first_sync_bookmarks))
+        second_sync_bookmark_date = self.get_second_sync_bookmark_date()
+        new_states = {'currently_syncing': None,
+                      "bookmarks": {"performance_report_device": {"https://www.stitchdata.com/": {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}},
+                                     "performance_report_page": {"https://www.stitchdata.com/": {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}}, 
+                                     "performance_report_country": {"https://www.stitchdata.com/": {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}},
+                                     "performance_report_query": {"https://www.stitchdata.com/": {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}},
+                                     "performance_report_date": {"https://www.stitchdata.com/": {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}},
+                                     "performance_report_custom": {"https://www.stitchdata.com/": {"image": second_sync_bookmark_date, "web": second_sync_bookmark_date, "video": second_sync_bookmark_date}}}}
+
+        menagerie.set_state(conn_id, new_states)
+        LOGGER.info("New Bookmark: {}".format(menagerie.get_state(conn_id)))
+
+        ##########################################################################
+        # Second Sync
+        ##########################################################################
+
+        second_sync_record_count = self.run_and_verify_sync(conn_id)
+        second_sync_records = runner.get_records_from_target_output()
+        second_sync_bookmarks = menagerie.get_state(conn_id)
+
+        ##########################################################################
+        # Third Sync: 
+        #   To test that we get at least one record per replication
+        #   Assuming that there no are new records between 2nd and 3rd sync there should only one record,
+        #   otherwise we should get more than 1 records
+        ##########################################################################
+
+        third_sync_record_count = self.run_and_verify_sync(conn_id)
+        third_sync_bookmarks = menagerie.get_state(conn_id)
+
+        ##########################################################################
+        # Test By Stream
+        ##########################################################################
+
+        for stream in expected_streams:
+            with self.subTest(stream=stream):
+
+                # expected values
+                expected_replication_method = expected_replication_methods[stream]
+
+                # collect information for assertions from syncs 1 & 2 base on expected values
+                first_sync_count = first_sync_record_count.get(stream, 0)
+                second_sync_count = second_sync_record_count.get(stream, 0)
+                first_sync_messages = [record.get('data') for record in
+                                       first_sync_records.get(
+                                           stream, {}).get('messages', [])
+                                       if record.get('action') == 'upsert']
+
+                second_sync_messages = [record.get('data') for record in
+                                        second_sync_records.get(
+                                            stream, {}).get('messages', [])
+                                        if record.get('action') == 'upsert']
+
+                first_bookmark_value = first_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
+                second_bookmark_value = second_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
+
+                # collect information for assertions from syncs 1 & 2 base on expected values
+                third_sync_count = third_sync_record_count.get(stream, 0)
+                third_bookmark_value = third_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
+
+                if expected_replication_method == self.INCREMENTAL:
+
+                    # collect information specific to incremental streams from syncs 1 & 2
+                    replication_key = next(iter(expected_replication_keys[stream]))
+                    
+                    simulated_bookmark_value = new_states['bookmarks'][stream]
+                    
+                    # Verify the first sync sets a bookmark of the expected form
+                    self.assertIsNotNone(first_bookmark_value)
+
+                    # Verify the second sync sets a bookmark of the expected form
+                    self.assertIsNotNone(second_bookmark_value)
+
+                    # Verify second sync record count is less than or equal to first sync record
+                    self.assertLessEqual(second_sync_count, first_sync_count)
+
+                    # Verify the second sync bookmark is Greater or Equal to the first sync bookmark
+                    self.assertGreaterEqual(second_bookmark_value.get(replication_key), first_bookmark_value.get(replication_key))
+
+                    for record in first_sync_messages:
+
+                        # Verify the first sync bookmark value is the max replication key value for a given stream
+                        replication_key_value = record.get(replication_key)
+   
+                        self.assertLessEqual(replication_key_value,
+                                            first_bookmark_value[replication_key],
+                                            msg="First sync bookmark was set incorrectly, a record with a greater replication-key value was synced.")
+                    
+                    for record in second_sync_messages:
+                        # Verify the second sync replication key value is Greater or Equal to the first sync bookmark
+                        replication_key_value = record.get(replication_key)
+
+                        self.assertLessEqual(simulated_bookmark_value[replication_key],
+                                            replication_key_value,
+                                            msg="Second sync bookmark was set incorrectly, a record with a greater replication-key value was synced.")
+
+                        # Verify the second sync bookmark value is the max replication key value for a given stream
+                        self.assertLessEqual(replication_key_value,
+                                            second_bookmark_value[replication_key],
+                                            msg="Second sync bookmark was set incorrectly, a record with a greater replication-key value was synced.")
+                        
+                # Verify at least 1 record was replicated in the second sync
+                self.assertGreater(second_sync_count, 0, msg="We are not fully testing bookmarking for {}".format(stream))
+
+                # Verify at least 1 record was replicated in the third sync
+                if second_bookmark_value[replication_key] == third_bookmark_value[replication_key]:
+                    self.assertEquals(third_sync_count, 1, msg="We are not fully testing bookmarking for {}".format(stream))
+                else:
+                    self.assertGreater(third_sync_count, 1, msg="We are not fully testing bookmarking for {}".format(stream))

--- a/tests/test_gsc_interrupted_sync.py
+++ b/tests/test_gsc_interrupted_sync.py
@@ -28,8 +28,7 @@ class GoogleSearchConsoleInterruptedSyncTest(GoogleSearchConsoleBaseTest):
  
         # Excluding the custom report stream to decrease the CCI job duration
         # Currently custom report stream takes more than an hour to sync data for past 14 days
-        exclude_streams = {'performance_report_custom'} 
-        expected_streams = self.expected_streams() - exclude_streams
+        expected_streams = self.expected_streams() - self.exclude_streams()
         expected_replication_keys = self.expected_replication_keys()
         expected_replication_methods = self.expected_replication_method()
         site_url = self.get_properties().get('site_urls', []).split(',')[0]
@@ -42,7 +41,7 @@ class GoogleSearchConsoleInterruptedSyncTest(GoogleSearchConsoleBaseTest):
         # Run in check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
-        # table and field selection
+        # Table and field selection
         catalog_entries = [catalog for catalog in found_catalogs if catalog.get('tap_stream_id') in expected_streams]
 
         self.perform_and_verify_table_and_field_selection(conn_id, catalog_entries)
@@ -93,10 +92,10 @@ class GoogleSearchConsoleInterruptedSyncTest(GoogleSearchConsoleBaseTest):
         for stream in expected_streams:
             with self.subTest(stream=stream):
 
-                # expected values
+                # Expected values
                 expected_replication_method = expected_replication_methods[stream]
 
-                # collect information for assertions from syncs 1 & 2 base on expected values
+                # Collect information for assertions from syncs 1 & 2 base on expected values
                 first_sync_count = first_sync_record_count.get(stream, 0)
                 second_sync_count = second_sync_record_count.get(stream, 0)
                 second_sync_messages = [record.get('data') for record in
@@ -107,11 +106,8 @@ class GoogleSearchConsoleInterruptedSyncTest(GoogleSearchConsoleBaseTest):
 
                 if expected_replication_method == self.INCREMENTAL:
 
-                    # collect information specific to incremental streams from syncs 1 & 2
+                    # Collect information specific to incremental streams from syncs 1 & 2
                     replication_key = next(iter(expected_replication_keys[stream]))
-
-                    if stream == 'performance_report_page':
-                        replication_key = 'date'
 
                     interrupted_bookmark_value = interrupted_sync_states['bookmarks'][stream]
                     if stream in completed_streams:

--- a/tests/test_gsc_interrupted_sync.py
+++ b/tests/test_gsc_interrupted_sync.py
@@ -1,0 +1,148 @@
+from datetime import datetime as dt
+from datetime import timedelta
+from tap_tester import connections, menagerie, runner
+from base import GoogleSearchConsoleBaseTest
+from tap_tester.logger import LOGGER
+
+
+class GoogleSearchConsoleInterruptedSyncTest(GoogleSearchConsoleBaseTest):
+
+    def name(self):
+        return "tap_tester_google_search_console_interrupted_sync_test"
+    
+    @staticmethod
+    def get_second_sync_bookmark_date(self):
+        return dt.strftime(dt.utcnow()-timedelta(days=2), self.START_DATE_FORMAT)
+
+    def test_run(self):
+        """
+        - Verify an interrupted sync can resume based on the currently_syncing and stream level bookmark value.
+        - Verify only records with replication-key values greater than or equal to the stream level bookmark 
+          are replicated on the resuming sync for the interrupted stream.
+        - Verify the yet-to-be-synced streams are replicated following the interrupted stream in the resuming sync. 
+          (All yet-to-be-synced streams must replicate before streams that were already synced)
+        """
+        
+        expected_streams = self.expected_streams()
+        expected_replication_keys = self.expected_replication_keys()
+        expected_replication_methods = self.expected_replication_method()
+
+        ##########################################################################
+        # First Sync
+        ##########################################################################
+        conn_id = connections.ensure_connection(self)
+
+        # Run in check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # table and field selection
+        catalog_entries = [catalog for catalog in found_catalogs
+                           if catalog.get('tap_stream_id') in expected_streams]
+        
+        self.perform_and_verify_table_and_field_selection(
+            conn_id, catalog_entries)
+
+        # Run a first sync job using orchestrator
+        first_sync_record_count = self.run_and_verify_sync(conn_id)
+        first_sync_records = runner.get_records_from_target_output()
+        first_sync_bookmarks = menagerie.get_state(conn_id)
+
+        ##########################################################################
+        # Update State Between Syncs
+        ##########################################################################
+        
+        LOGGER.info("Current Bookmark: {}".format(first_sync_bookmarks))
+        interrupted_sync_states = { 'currently_syncing': 'performance_report_date',
+                                    'bookmarks': {'performance_report_custom': first_sync_bookmarks.get('bookmarks', {}).get('performance_report_custom', {}),
+                                    'performance_report_query': first_sync_bookmarks.get('bookmarks', {}).get('performance_report_query', {}),
+                                    'performance_report_date': {list(expected_replication_keys['messages'])[0]: self.get_second_sync_bookmark_date()},
+                                    'performance_report_country': {list(expected_replication_keys['activity_logs'])[0]: self.start_date},
+                                    'performance_report_page': {list(expected_replication_keys['activity_logs'])[0]: self.start_date},
+                                    'performance_report_device': {list(expected_replication_keys['activity_logs'])[0]: self.start_date}}}        
+        completed_streams = ['performance_report_custom', 'performance_report_query']
+        pending_streams = ['performance_report_country', 'performance_report_page', 'performance_report_device']
+
+        menagerie.set_state(conn_id, interrupted_sync_states)
+
+        ##########################################################################
+        # Second Sync
+        ##########################################################################
+
+        second_sync_record_count = self.run_and_verify_sync(conn_id)
+        second_sync_records = runner.get_records_from_target_output()
+        second_sync_bookmarks = menagerie.get_state(conn_id)
+
+        ##########################################################################
+        # Test By Stream
+        ##########################################################################
+
+        for stream in expected_streams:
+            with self.subTest(stream=stream):
+
+                # expected values
+                expected_replication_method = expected_replication_methods[stream]
+
+                # collect information for assertions from syncs 1 & 2 base on expected values
+                first_sync_count = first_sync_record_count.get(stream, 0)
+                second_sync_count = second_sync_record_count.get(stream, 0)
+                # first_sync_messages = [record.get('data') for record in
+                #                        first_sync_records.get(
+                #                            stream, {}).get('messages', [])
+                #                        if record.get('action') == 'upsert']
+                second_sync_messages = [record.get('data') for record in
+                                        second_sync_records.get(
+                                            stream, {}).get('messages', [])
+                                        if record.get('action') == 'upsert']
+                first_bookmark_value = first_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
+                second_bookmark_value = second_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
+
+                if expected_replication_method == self.INCREMENTAL:
+
+                    # collect information specific to incremental streams from syncs 1 & 2
+                    replication_key = next(iter(expected_replication_keys[stream]))
+                    
+                    interrupted_bookmark_value = interrupted_sync_states['bookmarks'][stream]
+
+                    if stream in completed_streams:
+                        # Verify at least 1 record was replicated in the third sync
+                        if second_bookmark_value[replication_key] == first_bookmark_value[replication_key]:
+                            self.assertEquals(second_sync_count,
+                                            1, 
+                                            msg="Incorrent bookmarking for {}, at least one record should be replicated".format(stream))
+                        else:
+                            self.assertGreater(second_sync_count,
+                                                1,
+                                                msg="Incorrent bookmarking for {}, more than one records should be replicated if second sync bookmark is greater than first sync".format(stream))
+
+                    elif stream == interrupted_sync_states.get('currently_syncing', None):
+                        # For interrupted stream records sync count should be less equals
+                        self.assertLessEqual(second_sync_count,
+                                            first_sync_count,
+                                            msg="For interrupted stream, seconds sync record count should be lesser or equal to first sync".format(stream))
+
+                    elif stream in pending_streams:
+                        # First sync and second sync record count match
+                        if second_bookmark_value[replication_key] == first_bookmark_value[replication_key]:
+                            self.assertEquals(second_sync_count,
+                                            first_sync_count,
+                                            msg="For pending sync stream, if bookmark values are same for first and second sync, record should match".format(stream))
+                        else:
+                            self.assertGreaterEqual(second_sync_count,
+                                                    first_sync_count,
+                                                    msg="For pending sync streams, second sync record count should be more than first sync".format(stream))     
+
+                    else:
+                        raise Exception("Invalid state of stream {0} in interrupted state, please update appropriate state for the stream".format(stream))
+                    
+                    for record in second_sync_messages:
+                        # Verify the second sync replication key value is Greater or Equal to the first sync bookmark
+                        replication_key_value = record.get(replication_key)
+
+                        self.assertLessEqual(interrupted_bookmark_value[replication_key],
+                                            replication_key_value,
+                                            msg="Second sync bookmark was set incorrectly, a record with a greater replication-key value was synced.")
+
+                        # Verify the second sync bookmark value is the max replication key value for a given stream
+                        self.assertLessEqual(replication_key_value,
+                                            second_bookmark_value[replication_key],
+                                            msg="Second sync bookmark was set incorrectly, a record with a greater replication-key value was synced.")

--- a/tests/test_gsc_interrupted_sync.py
+++ b/tests/test_gsc_interrupted_sync.py
@@ -95,7 +95,7 @@ class GoogleSearchConsoleInterruptedSyncTest(GoogleSearchConsoleBaseTest):
                 # Expected values
                 expected_replication_method = expected_replication_methods[stream]
 
-                # Collect information for assertions from syncs 1 & 2 base on expected values
+                # Collect information for assertions from syncs 1 & 2 based on expected values
                 first_sync_count = first_sync_record_count.get(stream, 0)
                 second_sync_count = second_sync_record_count.get(stream, 0)
                 second_sync_messages = [record.get('data') for record in

--- a/tests/test_gsc_interrupted_sync.py
+++ b/tests/test_gsc_interrupted_sync.py
@@ -107,7 +107,9 @@ class GoogleSearchConsoleInterruptedSyncTest(GoogleSearchConsoleBaseTest):
                 if expected_replication_method == self.INCREMENTAL:
 
                     # Collect information specific to incremental streams from syncs 1 & 2
-                    replication_key = next(iter(expected_replication_keys[stream]))
+                    # Set date as replication key for performance_report_page since only date is being used for filtering
+                    replication_key = next(iter(expected_replication_keys[stream])) \
+                        if stream != 'performance_report_page' else 'date'
 
                     interrupted_bookmark_value = interrupted_sync_states['bookmarks'][stream]
                     if stream in completed_streams:

--- a/tests/test_gsc_interrupted_sync.py
+++ b/tests/test_gsc_interrupted_sync.py
@@ -7,12 +7,15 @@ from tap_tester.logger import LOGGER
 
 class GoogleSearchConsoleInterruptedSyncTest(GoogleSearchConsoleBaseTest):
 
-    def name(self):
-        return "tap_tester_google_search_console_interrupted_sync_test"
-    
     @staticmethod
+    def name():
+        return "tap_tester_google_search_console_interrupted_sync"
+
     def get_second_sync_bookmark_date(self):
-        return dt.strftime(dt.utcnow()-timedelta(days=2), self.START_DATE_FORMAT)
+        return dt.strftime(dt.utcnow()-timedelta(days=2), "%Y-%m-%dT00:00:00.000000Z")
+
+    def get_start_date(self):
+        return dt.strftime(self.start_date, "%Y-%m-%dT00:00:00.000000Z")
 
     def test_run(self):
         """
@@ -22,10 +25,14 @@ class GoogleSearchConsoleInterruptedSyncTest(GoogleSearchConsoleBaseTest):
         - Verify the yet-to-be-synced streams are replicated following the interrupted stream in the resuming sync. 
           (All yet-to-be-synced streams must replicate before streams that were already synced)
         """
-        
-        expected_streams = self.expected_streams()
+ 
+        # Excluding the custom report stream to decrease the CCI job duration
+        # Currently custom report stream takes more than an hour to sync data for past 14 days
+        exclude_streams = {'performance_report_custom'} 
+        expected_streams = self.expected_streams() - exclude_streams
         expected_replication_keys = self.expected_replication_keys()
         expected_replication_methods = self.expected_replication_method()
+        site_url = self.get_properties().get('site_urls', []).split(',')[0]
 
         ##########################################################################
         # First Sync
@@ -36,30 +43,38 @@ class GoogleSearchConsoleInterruptedSyncTest(GoogleSearchConsoleBaseTest):
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
         # table and field selection
-        catalog_entries = [catalog for catalog in found_catalogs
-                           if catalog.get('tap_stream_id') in expected_streams]
-        
-        self.perform_and_verify_table_and_field_selection(
-            conn_id, catalog_entries)
+        catalog_entries = [catalog for catalog in found_catalogs if catalog.get('tap_stream_id') in expected_streams]
+
+        self.perform_and_verify_table_and_field_selection(conn_id, catalog_entries)
 
         # Run a first sync job using orchestrator
         first_sync_record_count = self.run_and_verify_sync(conn_id)
         first_sync_records = runner.get_records_from_target_output()
         first_sync_bookmarks = menagerie.get_state(conn_id)
 
+
         ##########################################################################
         # Update State Between Syncs
         ##########################################################################
-        
+
         LOGGER.info("Current Bookmark: {}".format(first_sync_bookmarks))
-        interrupted_sync_states = { 'currently_syncing': 'performance_report_date',
-                                    'bookmarks': {'performance_report_custom': first_sync_bookmarks.get('bookmarks', {}).get('performance_report_custom', {}),
-                                    'performance_report_query': first_sync_bookmarks.get('bookmarks', {}).get('performance_report_query', {}),
-                                    'performance_report_date': {list(expected_replication_keys['messages'])[0]: self.get_second_sync_bookmark_date()},
-                                    'performance_report_country': {list(expected_replication_keys['activity_logs'])[0]: self.start_date},
-                                    'performance_report_page': {list(expected_replication_keys['activity_logs'])[0]: self.start_date},
-                                    'performance_report_device': {list(expected_replication_keys['activity_logs'])[0]: self.start_date}}}        
-        completed_streams = ['performance_report_custom', 'performance_report_query']
+        interrupted_sync_states = {'currently_syncing': 'performance_report_date',
+                                    'bookmarks': {'performance_report_query': {site_url: {'web': first_sync_bookmarks.get('bookmarks', {}).get('performance_report_query', {}).get(site_url).get('web'),
+                                                                                          'image': first_sync_bookmarks.get('bookmarks', {}).get('performance_report_query', {}).get(site_url).get('image'),
+                                                                                          'video': first_sync_bookmarks.get('bookmarks', {}).get('performance_report_query', {}).get(site_url).get('video')}},
+                                    'performance_report_date': {site_url: {'web': self.get_second_sync_bookmark_date(),
+                                                                           'image': self.get_second_sync_bookmark_date(),
+                                                                           'video': self.get_second_sync_bookmark_date()}},
+                                    'performance_report_country': {site_url: {'web': self.get_start_date(),
+                                                                           'image': self.get_start_date(),
+                                                                           'video': self.get_start_date()}},
+                                    'performance_report_page': {site_url: {'web': self.get_start_date(),
+                                                                           'image': self.get_start_date(),
+                                                                           'video': self.get_start_date()}},
+                                    'performance_report_device': {site_url: {'web': self.get_start_date(),
+                                                                           'image': self.get_start_date(),
+                                                                           'video': self.get_start_date()}}}}
+        completed_streams = ['performance_report_query']
         pending_streams = ['performance_report_country', 'performance_report_page', 'performance_report_device']
 
         menagerie.set_state(conn_id, interrupted_sync_states)
@@ -71,7 +86,6 @@ class GoogleSearchConsoleInterruptedSyncTest(GoogleSearchConsoleBaseTest):
         second_sync_record_count = self.run_and_verify_sync(conn_id)
         second_sync_records = runner.get_records_from_target_output()
         second_sync_bookmarks = menagerie.get_state(conn_id)
-
         ##########################################################################
         # Test By Stream
         ##########################################################################
@@ -85,33 +99,24 @@ class GoogleSearchConsoleInterruptedSyncTest(GoogleSearchConsoleBaseTest):
                 # collect information for assertions from syncs 1 & 2 base on expected values
                 first_sync_count = first_sync_record_count.get(stream, 0)
                 second_sync_count = second_sync_record_count.get(stream, 0)
-                # first_sync_messages = [record.get('data') for record in
-                #                        first_sync_records.get(
-                #                            stream, {}).get('messages', [])
-                #                        if record.get('action') == 'upsert']
                 second_sync_messages = [record.get('data') for record in
                                         second_sync_records.get(
                                             stream, {}).get('messages', [])
                                         if record.get('action') == 'upsert']
-                first_bookmark_value = first_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
                 second_bookmark_value = second_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
 
                 if expected_replication_method == self.INCREMENTAL:
 
                     # collect information specific to incremental streams from syncs 1 & 2
                     replication_key = next(iter(expected_replication_keys[stream]))
-                    
-                    interrupted_bookmark_value = interrupted_sync_states['bookmarks'][stream]
 
+                    if stream == 'performance_report_page':
+                        replication_key = 'date'
+
+                    interrupted_bookmark_value = interrupted_sync_states['bookmarks'][stream]
                     if stream in completed_streams:
-                        # Verify at least 1 record was replicated in the third sync
-                        if second_bookmark_value[replication_key] == first_bookmark_value[replication_key]:
-                            self.assertEquals(second_sync_count,
-                                            1, 
-                                            msg="Incorrent bookmarking for {}, at least one record should be replicated".format(stream))
-                        else:
-                            self.assertGreater(second_sync_count,
-                                                1,
+                        # Verify at least 1 record was replicated in the second sync
+                        self.assertGreaterEqual(second_sync_count, 1,
                                                 msg="Incorrent bookmarking for {}, more than one records should be replicated if second sync bookmark is greater than first sync".format(stream))
 
                     elif stream == interrupted_sync_states.get('currently_syncing', None):
@@ -122,27 +127,21 @@ class GoogleSearchConsoleInterruptedSyncTest(GoogleSearchConsoleBaseTest):
 
                     elif stream in pending_streams:
                         # First sync and second sync record count match
-                        if second_bookmark_value[replication_key] == first_bookmark_value[replication_key]:
-                            self.assertEquals(second_sync_count,
-                                            first_sync_count,
-                                            msg="For pending sync stream, if bookmark values are same for first and second sync, record should match".format(stream))
-                        else:
-                            self.assertGreaterEqual(second_sync_count,
-                                                    first_sync_count,
-                                                    msg="For pending sync streams, second sync record count should be more than first sync".format(stream))     
+                        self.assertGreaterEqual(second_sync_count, first_sync_count,
+                                                msg="For pending sync streams, second sync record count should be more than first sync".format(stream))     
 
                     else:
                         raise Exception("Invalid state of stream {0} in interrupted state, please update appropriate state for the stream".format(stream))
-                    
+ 
                     for record in second_sync_messages:
+                        # Get the search_type of the record to fetch the appropriate bookmark value from interrupted_bookmarks
+                        search_type = record.get('search_type', 'web')
                         # Verify the second sync replication key value is Greater or Equal to the first sync bookmark
                         replication_key_value = record.get(replication_key)
 
-                        self.assertLessEqual(interrupted_bookmark_value[replication_key],
-                                            replication_key_value,
+                        self.assertLessEqual(interrupted_bookmark_value.get(site_url).get(search_type), replication_key_value,
                                             msg="Second sync bookmark was set incorrectly, a record with a greater replication-key value was synced.")
 
                         # Verify the second sync bookmark value is the max replication key value for a given stream
-                        self.assertLessEqual(replication_key_value,
-                                            second_bookmark_value[replication_key],
+                        self.assertLessEqual(replication_key_value, second_bookmark_value.get(site_url).get(search_type),
                                             msg="Second sync bookmark was set incorrectly, a record with a greater replication-key value was synced.")

--- a/tests/test_gsc_pagination_test.py
+++ b/tests/test_gsc_pagination_test.py
@@ -9,7 +9,7 @@ class PaginationTest(GoogleSearchConsoleBaseTest):
         return "tap_tester_google_search_console_pagination_test"
 
     def test_run(self):
-        # page size for "performance_report_custom"
+        # Page size for "performance_report_custom"
         page_size = 10000
         conn_id = connections.ensure_connection(self)
 
@@ -17,7 +17,7 @@ class PaginationTest(GoogleSearchConsoleBaseTest):
         expected_streams = ["performance_report_page"]
         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
-        # table and field selection
+        # Table and field selection
         test_catalogs = [catalog for catalog in found_catalogs
                          if catalog.get('stream_name') in expected_streams]
 
@@ -29,17 +29,17 @@ class PaginationTest(GoogleSearchConsoleBaseTest):
 
         for stream in expected_streams:
             with self.subTest(stream=stream):
-                # expected values
+                # Expected values
                 expected_primary_keys = self.expected_primary_keys()[stream]
 
-                # collect information for assertions from syncs 1 & 2 base on expected values
+                # Collect information for assertions from syncs 1 & 2 base on expected values
                 record_count_sync = record_count_by_stream.get(stream, 0)
                 primary_keys_list = [tuple(message.get('data').get(expected_pk)
                                            for expected_pk in expected_primary_keys)
                                      for message in synced_records.get(stream).get('messages')
                                      if message.get('action') == 'upsert']
 
-                # verify records are more than page size so multiple page is working
+                # Verify records are more than page size so multiple page is working
                 self.assertGreater(record_count_sync, page_size)
 
                 primary_keys_list_1 = primary_keys_list[:page_size]

--- a/tests/test_gsc_start_date.py
+++ b/tests/test_gsc_start_date.py
@@ -1,7 +1,5 @@
-import os
-
 from tap_tester import connections, runner
-
+from tap_tester.logger import LOGGER
 from base import GoogleSearchConsoleBaseTest
 
 
@@ -51,7 +49,7 @@ class GoogleSearchConsoleStartDateTest(GoogleSearchConsoleBaseTest):
         ### Update START DATE Between Syncs
         ##########################################################################
 
-        print("REPLICATION START DATE CHANGE: {} ===>>> {} ".format(self.start_date, self.start_date_2))
+        LOGGER.info("REPLICATION START DATE CHANGE: {} ===>>> {} ".format(self.start_date, self.start_date_2))
         self.start_date = self.start_date_2
 
         ##########################################################################


### PR DESCRIPTION
# Description of change

- add missing integration tests (all_fields, automatic_fields, bookmark, interrupted_sync)
- replaced print statements in base.py with tap_tester Logger
- skipping tests for stream `performance_report_custom` since its taking more than 1 hour to sync data

# Manual QA steps
 - Ran all the tests on dev-vm to make sure all of them pass
 
# Risks
 - Low, CCI would be failing until sandbox is up
 
# Rollback steps
 - revert this branch
